### PR TITLE
Enable publishing on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,11 +36,11 @@ jobs:
       - store_test_results:
           path: ~/junit
 
-#      - deploy:
-#          command: |
-#            if [[ "${CIRCLE_BRANCH}" == "develop" || "${CIRCLE_TAG}" =~ [0-9]+(\.[0-9]+)+(-[a-zA-Z]+[0-9]*)* ]]; then
-#              ./gradlew --stacktrace --continue publish
-#            fi
+      - deploy:
+          command: |
+            if [[ "${CIRCLE_BRANCH}" == "develop" || "${CIRCLE_TAG}" =~ [0-9]+(\.[0-9]+)+(-[a-zA-Z]+[0-9]*)* ]]; then
+              ./gradlew --stacktrace --continue publish
+            fi
 
 workflows:
   version: 2


### PR DESCRIPTION
Need to ensure our bintray creds allow publishing the `gradle-conjure` pkg.