### PR TITLE
:gradle-conjure-api no longer depends on guava

### DIFF
--- a/gradle-conjure-api/build.gradle
+++ b/gradle-conjure-api/build.gradle
@@ -18,5 +18,4 @@ apply from: "$rootDir/gradle/publish-jar.gradle"
 
 dependencies {
     compile localGroovy()
-    compile 'com.google.guava:guava'
 }

--- a/gradle-conjure-api/src/main/java/com/palantir/gradle/conjure/api/GeneratorOptions.java
+++ b/gradle-conjure-api/src/main/java/com/palantir/gradle/conjure/api/GeneratorOptions.java
@@ -16,9 +16,8 @@
 
 package com.palantir.gradle.conjure.api;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -26,8 +25,9 @@ import java.util.regex.Pattern;
 
 public final class GeneratorOptions implements Serializable {
     private static final long serialVersionUID = 5676541916502995769L;
+
     /** Keys must be defined in camelCase. */
-    private static Predicate<String> expectedKeyPattern = Pattern.compile("[a-z][a-zA-Z0-9]*").asPredicate();
+    private static Predicate<String> camelCase = Pattern.compile("[a-z][a-zA-Z0-9]*").asPredicate();
     private final Map<String, Object> storage = new LinkedHashMap<>();
 
     public void setProperty(String name, Object newValue) {
@@ -39,7 +39,7 @@ public final class GeneratorOptions implements Serializable {
     }
 
     public Map<String, Object> getProperties() {
-        return ImmutableMap.copyOf(this.storage);
+        return Collections.unmodifiableMap(this.storage);
     }
 
     public boolean has(String name) {
@@ -54,10 +54,19 @@ public final class GeneratorOptions implements Serializable {
         }
     }
 
-    private void set(String name, Object value) {
-        Preconditions.checkNotNull(name, "Key cannot be null");
-        Preconditions.checkArgument(expectedKeyPattern.test(name), "Key must be camelCase: %s", name);
-        Preconditions.checkNotNull(value, "Property '%s': value cannot be null", name);
-        this.storage.put(name, value);
+    private void set(String key, Object value) {
+        if (key == null) {
+            throw new NullPointerException("Key cannot be null: " + key);
+        }
+
+        if (!camelCase.test(key)) {
+            throw new IllegalArgumentException("Key must be camelCase: " + key);
+        }
+
+        if (value == null) {
+            throw new NullPointerException(String.format("Property '%s': value cannot be null", key));
+        }
+
+        this.storage.put(key, value);
     }
 }


### PR DESCRIPTION
Follow-up to https://github.com/palantir/gradle-conjure/pull/9, I want to make it as safe as possible for people to build plugins against the `gradle-conjure-api` jar.