### PR TITLE
[fix] python: prepend 'g' to hash in case of snapshot version

### DIFF
--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileConjurePythonTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileConjurePythonTask.java
@@ -56,7 +56,8 @@ public class CompileConjurePythonTask extends ConjureGeneratorTask {
         getGroup(matcher, "distance").ifPresent(distance -> {
             String hash = getGroup(matcher, "hash")
                     .orElseThrow(() -> new InvalidUserDataException("Cannot specify commit distance without hash"));
-            version.append("+").append(distance).append(".").append(hash);
+            // We prefix 'g' to the hash because conda strips leading zeros!!
+            version.append("+").append(distance).append(".").append("g" + hash);
         });
         getGroup(matcher, "dirty").ifPresent(dirty -> version.append('.').append(dirty));
         return version.toString();


### PR DESCRIPTION
## Before this PR

Python version stripped out the 'g' coming from the project version (expected to be in `git describe` format).
Apparently conda strips leading zeroes so this breaks versions whose commit hash starts with '0'.

## After this PR

Always prepend 'g' to the snapshot commit hash (just like `git describe` does).