### PR TITLE
Upgrade bintray plugin to unblock publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'com.netflix.nebula:nebula-publishing-plugin:7.2.3'
         classpath 'com.palantir.baseline:gradle-baseline-java:0.34.0'
         classpath 'com.palantir.configurationresolver:gradle-configuration-resolver-plugin:0.3.0'


### PR DESCRIPTION
The 4.5.0-rc3 tag build failed: https://circleci.com/gh/palantir/gradle-conjure/288

```
Could not upload to 'https://api.bintray.com/content/palantir/releases/gradle-conjure/4.5.0-rc3/property(class java/lang/String, transform(provider(?)))/property(class java.lang.String, transform(provider(?)))/property(class java.lang.String, transform(provider(?)))/property(class java.lang.String, transform(provider(?)))-property(class java.lang.String, transform(provider(?)))-sources.jar': HTTP/1.1 403 Forbidden [message:forbidden]
```

Frustrating that excavator didn't open this PR for us, but oh well.