### PR TITLE
Cache python, typescript name and version

### DIFF
--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileConjurePythonTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileConjurePythonTask.java
@@ -24,14 +24,15 @@ import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.tasks.Input;
 
 public class CompileConjurePythonTask extends ConjureGeneratorTask {
 
     @Override
     protected final Map<String, Supplier<Object>> requiredOptions(File file) {
         return ImmutableMap.of(
-                "packageName", () -> getProject().getName(),
-                "packageVersion", () -> formatPythonVersion(getProject().getVersion().toString()));
+                "packageName", this::getProjectName,
+                "packageVersion", this::getPackageVersion);
     }
 
     private static final Pattern gradleVersion = Pattern.compile("^"
@@ -40,6 +41,16 @@ public class CompileConjurePythonTask extends ConjureGeneratorTask {
             + "(-(?<distance>[0-9]+)-g(?<hash>[a-f0-9]+))?"
             + "(\\.(?<dirty>dirty))?"
             + "$");
+
+    @Input
+    public final String getProjectName() {
+        return getProject().getName();
+    }
+
+    @Input
+    public final String getPackageVersion() {
+        return formatPythonVersion(getProject().getVersion().toString());
+    }
 
     private static String formatPythonVersion(String stringVersion) {
         if (stringVersion.equals("unspecified")) {

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileConjureTypeScriptTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileConjureTypeScriptTask.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.gradle.api.file.ConfigurableFileTree;
+import org.gradle.api.tasks.Input;
 
 public class CompileConjureTypeScriptTask extends ConjureGeneratorTask {
 
@@ -35,7 +36,17 @@ public class CompileConjureTypeScriptTask extends ConjureGeneratorTask {
     @Override
     protected final Map<String, Supplier<Object>> requiredOptions(File file) {
         return ImmutableMap.of(
-                "packageName", () -> getProject().getName(),
-                "packageVersion", () -> getProject().getVersion().toString());
+                "packageName", this::getPackageName,
+                "packageVersion", this::getProjectVersion);
+    }
+
+    @Input
+    private String getPackageName() {
+        return getProject().getName();
+    }
+
+    @Input
+    private String getProjectVersion() {
+        return getProject().getVersion().toString();
     }
 }


### PR DESCRIPTION
## Before this PR

`compileConjurePython` produces different outputs based on project name and version. However, if only these change, the task is still considered up to date.

Same for `compileConjureTypeScript`.

## After this PR

Either task will run again if you change version / name.