### PR TITLE
[fix] Add guava dependency when using retrofitListenableFutures

### DIFF
--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -253,6 +253,9 @@ public final class ConjurePlugin implements Plugin<Project> {
                 subproj.getDependencies().add("compile", project.findProject(objectsProjectName));
                 subproj.getDependencies().add("compile", "com.squareup.retrofit2:retrofit");
                 subproj.getDependencies().add("compileOnly", "javax.annotation:javax.annotation-api");
+                if (optionsSupplier.get().has("retrofitListenableFutures")) {
+                    subproj.getDependencies().add("compile", "com.google.gauva:gauva");
+                }
             });
         }
     }

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -455,6 +455,22 @@ class ConjurePluginTest extends IntegrationSpec {
         file('api/api-retrofit/src/generated/java/test/test/api/TestServiceFooRetrofit.java').text.contains('CompletableFuture<StringExample>')
     }
 
+    def 'featureFlag RetrofitListenableFutures can be enabled'() {
+        file('api/build.gradle') << '''
+        conjure {
+            java {
+                retrofitListenableFutures = true
+            }
+        }
+        '''.stripIndent()
+
+        when:
+        ExecutionResult result = runTasksSuccessfully(':api:compileConjureRetrofit')
+
+        then:
+        fileExists('api/api-retrofit/src/generated/java/test/test/api/TestServiceFooRetrofit.java')
+        file('api/api-retrofit/src/generated/java/test/test/api/TestServiceFooRetrofit.java').text.contains('ListenableFuture<StringExample>')
+    }
 
     def 'typescript extension is respected'() {
          file('api/build.gradle') << '''


### PR DESCRIPTION
## Before this PR
The generated retrofit API project does not include a guava dependency when using `ListenableFuture`. This requires consumers to manually add the dependency

## After this PR
The conjure plugin now automatically adds the guava dependency when `ListenableFuture` is used.