### PR TITLE
[fix] com.palantir.conjure-local no longer hard-codes 'foo' and '0.0.0' for python

### DIFF
--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
@@ -161,13 +161,7 @@ public final class ConjureLocalPlugin implements Plugin<Project> {
             task.setSource(conjureIrConfiguration);
             task.setExecutablePath(extractConjurePythonTask::getExecutable);
             task.setOutputDirectory(subproj.file("python"));
-            task.setOptions(() -> {
-                GeneratorOptions generatorOptions = new GeneratorOptions(optionsSupplier.get());
-                // TODO(forozco): remove once rawSource option is added
-                generatorOptions.setProperty("packageName", "foo");
-                generatorOptions.setProperty("packageVersion", "0.0.0");
-                return generatorOptions;
-            });
+            task.setOptions(() -> optionsSupplier.get().addFlag("rawSource"));
             task.dependsOn(extractConjurePythonTask);
             generateConjure.dependsOn(task);
         });

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalPluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalPluginTest.groovy
@@ -39,7 +39,7 @@ class ConjureLocalPluginTest extends IntegrationSpec {
                resolutionStrategy {
                    failOnVersionConflict()
                    force 'com.palantir.conjure.typescript:conjure-typescript:3.1.1'
-                   force 'com.palantir.conjure.python:conjure-python:3.5.0'
+                   force 'com.palantir.conjure.python:conjure-python:3.9.0'
                    force 'com.palantir.conjure:conjure:4.0.0'
                    force 'com.palantir.conjure.postman:conjure-postman:0.1.0'
                }
@@ -69,7 +69,7 @@ class ConjureLocalPluginTest extends IntegrationSpec {
         result.wasExecuted(":generatePython")
 
         fileExists('typescript/src/conjure-api/index.ts')
-        fileExists('python/python/conjure-api/foo/__init__.py')
+        fileExists('python/python/conjure-api/conjure_spec/__init__.py')
     }
 
     def "custom generator throws if generator missing"() {


### PR DESCRIPTION
Closes #50 