### PR TITLE
[fix] Refactor to service dependencies

### DIFF
--- a/gradle-conjure-api/src/main/java/com/palantir/gradle/conjure/api/ConjureProductDependenciesExtension.java
+++ b/gradle-conjure-api/src/main/java/com/palantir/gradle/conjure/api/ConjureProductDependenciesExtension.java
@@ -23,18 +23,18 @@ import java.util.Set;
 
 public class ConjureProductDependenciesExtension {
 
-    public static final String EXTENSION_NAME = "productDependencies";
+    public static final String EXTENSION_NAME = "serviceDependencies";
 
-    private final Set<ProductDependency> productDependencies = new HashSet<>();
+    private final Set<ServiceDependency> productDependencies = new HashSet<>();
 
-    public final Set<ProductDependency> getProductDependencies() {
+    public final Set<ServiceDependency> getProductDependencies() {
         return productDependencies;
     }
 
-    public final void productDependency(@DelegatesTo(ProductDependency.class) Closure closure) {
-        ProductDependency productDependency = new ProductDependency();
-        closure.setDelegate(productDependency);
+    public final void serviceDependency(@DelegatesTo(ServiceDependency.class) Closure closure) {
+        ServiceDependency serviceDependency = new ServiceDependency();
+        closure.setDelegate(serviceDependency);
         closure.call();
-        productDependencies.add(productDependency);
+        productDependencies.add(serviceDependency);
     }
 }

--- a/gradle-conjure-api/src/main/java/com/palantir/gradle/conjure/api/ServiceDependency.java
+++ b/gradle-conjure-api/src/main/java/com/palantir/gradle/conjure/api/ServiceDependency.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.util.Objects;
 
-public final class ProductDependency implements Serializable {
+public final class ServiceDependency implements Serializable {
 
     @JsonProperty("product-group")
     private String productGroup;
@@ -85,7 +85,7 @@ public final class ProductDependency implements Serializable {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        ProductDependency that = (ProductDependency) obj;
+        ServiceDependency that = (ServiceDependency) obj;
         return Objects.equals(productGroup, that.productGroup)
                 && Objects.equals(productName, that.productName)
                 && Objects.equals(minimumVersion, that.minimumVersion)

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaServiceDependenciesTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaServiceDependenciesTask.java
@@ -28,7 +28,7 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.jvm.tasks.Jar;
 
 public class ConjureJavaServiceDependenciesTask extends DefaultTask {
-    public static final String SIS_RECOMMENCED_PRODUCT_DEPS_KEY = "Sls-Recommended-Product-Dependencies";
+    public static final String SLS_RECOMMENDED_PRODUCT_DEPENDENCIES = "Sls-Recommended-Product-Dependencies";
     private Supplier<Set<ServiceDependency>> serviceDependencies;
     private Project subproject;
 
@@ -50,7 +50,7 @@ public class ConjureJavaServiceDependenciesTask extends DefaultTask {
         for (Jar jarTask : subproject.getTasks().withType(Jar.class)) {
             jarTask.getManifest()
                     .getAttributes()
-                    .put(SIS_RECOMMENCED_PRODUCT_DEPS_KEY,
+                    .put(SLS_RECOMMENDED_PRODUCT_DEPENDENCIES,
                             GenerateConjureServiceDependenciesTask.jsonMapper.writeValueAsString(
                                     new RecommendedProductDependencies(getServiceDependencies())));
         }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaServiceDependenciesTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaServiceDependenciesTask.java
@@ -17,7 +17,7 @@
 package com.palantir.gradle.conjure;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.palantir.gradle.conjure.api.ProductDependency;
+import com.palantir.gradle.conjure.api.ServiceDependency;
 import java.io.IOException;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -27,18 +27,18 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.jvm.tasks.Jar;
 
-public class ConjureJavaProductDependenciesTask extends DefaultTask {
-    public static final String SLS_RECCOMENDED_PRODUCT_DEPS_KEY = "Sls-Recommended-Product-Dependencies";
-    private Supplier<Set<ProductDependency>> productDependencies;
+public class ConjureJavaServiceDependenciesTask extends DefaultTask {
+    public static final String SIS_RECOMMENCED_PRODUCT_DEPS_KEY = "Sls-Recommended-Product-Dependencies";
+    private Supplier<Set<ServiceDependency>> serviceDependencies;
     private Project subproject;
 
     @Input
-    public final Set<ProductDependency> getProductDependencies() {
-        return productDependencies.get();
+    public final Set<ServiceDependency> getServiceDependencies() {
+        return serviceDependencies.get();
     }
 
-    public final void setProductDependencies(Supplier<Set<ProductDependency>> productDependencies) {
-        this.productDependencies = productDependencies;
+    public final void setServiceDependencies(Supplier<Set<ServiceDependency>> serviceDependencies) {
+        this.serviceDependencies = serviceDependencies;
     }
 
     public final void setSubproject(Project subproject) {
@@ -46,22 +46,22 @@ public class ConjureJavaProductDependenciesTask extends DefaultTask {
     }
 
     @TaskAction
-    public final void populateProductDependencies() throws IOException {
+    public final void populateServiceDependencies() throws IOException {
         for (Jar jarTask : subproject.getTasks().withType(Jar.class)) {
             jarTask.getManifest()
                     .getAttributes()
-                    .put(SLS_RECCOMENDED_PRODUCT_DEPS_KEY,
-                            GenerateConjureProductDependenciesTask.jsonMapper.writeValueAsString(
-                                    new RecommendedProductDependencies(getProductDependencies())));
+                    .put(SIS_RECOMMENCED_PRODUCT_DEPS_KEY,
+                            GenerateConjureServiceDependenciesTask.jsonMapper.writeValueAsString(
+                                    new RecommendedProductDependencies(getServiceDependencies())));
         }
     }
 
     private static class RecommendedProductDependencies {
         @JsonProperty("recommended-product-dependencies")
-        private Set<ProductDependency> recommendedProductDependencies;
+        private Set<ServiceDependency> recommendedProductDependencies;
 
         RecommendedProductDependencies(
-                Set<ProductDependency> recommendedProductDependencies) {
+                Set<ServiceDependency> recommendedProductDependencies) {
             this.recommendedProductDependencies = recommendedProductDependencies;
         }
     }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -91,9 +91,9 @@ public final class ConjurePlugin implements Plugin<Project> {
 
         Copy copyConjureSourcesTask = getConjureSources(project, sourceDirectorySetFactory);
         Task compileIrTask = createCompileIrTask(project, copyConjureSourcesTask);
-        GenerateConjureProductDependenciesTask productDependencyTask = project.getTasks().create(
-                "generateConjureProductDependency", GenerateConjureProductDependenciesTask.class, task -> {
-                    task.setConjureProductDependencies(conjureProductDependenciesExtension::getProductDependencies);
+        GenerateConjureServiceDependenciesTask productDependencyTask = project.getTasks().create(
+                "generateConjureServiceDependencies", GenerateConjureServiceDependenciesTask.class, task -> {
+                    task.setConjureServiceDependencies(conjureProductDependenciesExtension::getProductDependencies);
                 });
 
         setupConjureJavaProject(
@@ -120,7 +120,7 @@ public final class ConjurePlugin implements Plugin<Project> {
             Supplier<GeneratorOptions> optionsSupplier,
             Task compileConjure,
             Task compileIrTask,
-            GenerateConjureProductDependenciesTask productDependencyTask) {
+            GenerateConjureServiceDependenciesTask productDependencyTask) {
         Set<String> javaProjectSuffixes = ImmutableSet.of(
                 JAVA_OBJECTS_SUFFIX, JAVA_JERSEY_SUFFIX, JAVA_RETROFIT_SUFFIX);
         if (javaProjectSuffixes.stream().anyMatch(suffix -> project.findProject(project.getName() + suffix) != null)) {
@@ -200,7 +200,7 @@ public final class ConjurePlugin implements Plugin<Project> {
             Supplier<GeneratorOptions> optionsSupplier,
             Task compileConjure,
             Task compileIrTask,
-            GenerateConjureProductDependenciesTask productDependencyTask,
+            GenerateConjureServiceDependenciesTask productDependencyTask,
             ExtractExecutableTask extractJavaTask) {
 
         String retrofitProjectName = project.getName() + JAVA_RETROFIT_SUFFIX;
@@ -254,7 +254,7 @@ public final class ConjurePlugin implements Plugin<Project> {
             Supplier<GeneratorOptions> optionsSupplier,
             Task compileConjure,
             Task compileIrTask,
-            GenerateConjureProductDependenciesTask productDependencyTask,
+            GenerateConjureServiceDependenciesTask productDependencyTask,
             ExtractExecutableTask extractJavaTask) {
 
         String jerseyProjectName = project.getName() + JAVA_JERSEY_SUFFIX;
@@ -309,7 +309,7 @@ public final class ConjurePlugin implements Plugin<Project> {
             Supplier<GeneratorOptions> options,
             Task compileConjure,
             Task compileIrTask,
-            GenerateConjureProductDependenciesTask productDependencyTask) {
+            GenerateConjureServiceDependenciesTask productDependencyTask) {
         String typescriptProjectName = project.getName() + "-typescript";
         if (project.findProject(typescriptProjectName) != null) {
             Configuration conjureTypeScriptConfig = project.getConfigurations().maybeCreate(CONJURE_TYPESCRIPT);
@@ -444,9 +444,9 @@ public final class ConjurePlugin implements Plugin<Project> {
     }
 
     private static Task createJavaProductDependenciesTask(Project project, Project subproj,
-            String taskName, GenerateConjureProductDependenciesTask productDependencyTask) {
-        return project.getTasks().create(taskName, ConjureJavaProductDependenciesTask.class, task -> {
-            task.setProductDependencies(productDependencyTask::getConjureProductDependencies);
+            String taskName, GenerateConjureServiceDependenciesTask productDependencyTask) {
+        return project.getTasks().create(taskName, ConjureJavaServiceDependenciesTask.class, task -> {
+            task.setServiceDependencies(productDependencyTask::getConjureServiceDependencies);
             task.setSubproject(subproj);
             task.dependsOn(productDependencyTask);
             subproj.getTasks().withType(Jar.class, jar -> jar.dependsOn(task));

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GenerateConjureServiceDependenciesTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GenerateConjureServiceDependenciesTask.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.google.common.base.Preconditions;
-import com.palantir.gradle.conjure.api.ProductDependency;
+import com.palantir.gradle.conjure.api.ServiceDependency;
 import com.palantir.sls.versions.SlsVersion;
 import com.palantir.sls.versions.SlsVersionMatcher;
 import java.io.File;
@@ -33,57 +33,57 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 
-public class GenerateConjureProductDependenciesTask extends DefaultTask {
+public class GenerateConjureServiceDependenciesTask extends DefaultTask {
     private static final Pattern GROUP_PATTERN = Pattern.compile("^[^:@?\\s]+");
     private static final Pattern NAME_PATTERN = Pattern.compile("^[^:@?\\s]+");
     public static final ObjectMapper jsonMapper = new ObjectMapper()
             .setSerializationInclusion(JsonInclude.Include.NON_NULL)
             .setPropertyNamingStrategy(PropertyNamingStrategy.KEBAB_CASE);
 
-    private Supplier<Set<ProductDependency>> conjureProductDependencies;
+    private Supplier<Set<ServiceDependency>> conjureServiceDependencies;
 
     @Input
-    public final Set<ProductDependency> getConjureProductDependencies() {
-        return conjureProductDependencies.get();
+    public final Set<ServiceDependency> getConjureServiceDependencies() {
+        return conjureServiceDependencies.get();
     }
 
     @OutputFile
     public final File getOutputFile() {
-        return new File(getProject().getBuildDir(), "product-dependencies.json");
+        return new File(getProject().getBuildDir(), "service-dependencies.json");
     }
 
-    final void setConjureProductDependencies(
-            Supplier<Set<ProductDependency>> conjureProductDependencies) {
-        this.conjureProductDependencies = conjureProductDependencies;
+    final void setConjureServiceDependencies(
+            Supplier<Set<ServiceDependency>> conjureServiceDependencies) {
+        this.conjureServiceDependencies = conjureServiceDependencies;
     }
 
     @TaskAction
-    public final void generateConjureProductDependencies() throws IOException {
-        getConjureProductDependencies().forEach(GenerateConjureProductDependenciesTask::validateProductDependency);
-        jsonMapper.writeValue(getOutputFile(), getConjureProductDependencies());
+    public final void generateConjureServiceDependencies() throws IOException {
+        getConjureServiceDependencies().forEach(GenerateConjureServiceDependenciesTask::validateServiceDependency);
+        jsonMapper.writeValue(getOutputFile(), getConjureServiceDependencies());
     }
 
-    private static void validateProductDependency(ProductDependency productDependency) {
-        Preconditions.checkNotNull(productDependency.getProductGroup(),
-                    "productGroup must be specified for a recommended product dependency");
-        Preconditions.checkArgument(GROUP_PATTERN.matcher(productDependency.getProductGroup()).matches(),
+    private static void validateServiceDependency(ServiceDependency serviceDependency) {
+        Preconditions.checkNotNull(serviceDependency.getProductGroup(),
+                    "productGroup must be specified for a recommended service dependency");
+        Preconditions.checkArgument(GROUP_PATTERN.matcher(serviceDependency.getProductGroup()).matches(),
                 "productGroup must be a valid maven group");
-        Preconditions.checkNotNull(productDependency.getProductName(),
-                    "productName must be specified for a recommended product dependency");
-        Preconditions.checkArgument(NAME_PATTERN.matcher(productDependency.getProductName()).matches(),
+        Preconditions.checkNotNull(serviceDependency.getProductName(),
+                    "productName must be specified for a recommended service dependency");
+        Preconditions.checkArgument(NAME_PATTERN.matcher(serviceDependency.getProductName()).matches(),
                 "productName must be a valid maven name");
-        Preconditions.checkNotNull(productDependency.getMinimumVersion(), "minimum version must be specified");
-        if (!SlsVersion.check(productDependency.getMaximumVersion())
-                && !SlsVersionMatcher.safeValueOf(productDependency.getMaximumVersion()).isPresent()) {
+        Preconditions.checkNotNull(serviceDependency.getMinimumVersion(), "minimum version must be specified");
+        if (!SlsVersion.check(serviceDependency.getMaximumVersion())
+                && !SlsVersionMatcher.safeValueOf(serviceDependency.getMaximumVersion()).isPresent()) {
             throw new IllegalArgumentException("maximumVersion must be valid SLS version or version matcher: "
-                    + productDependency.getMaximumVersion());
-        } else if (!SlsVersion.check(productDependency.getMinimumVersion())) {
+                    + serviceDependency.getMaximumVersion());
+        } else if (!SlsVersion.check(serviceDependency.getMinimumVersion())) {
             throw new IllegalArgumentException("minimumVersion must be valid SLS versions: "
-                    + productDependency.getMinimumVersion());
-        } else if (!SlsVersion.check(productDependency.getRecommendedVersion())) {
+                    + serviceDependency.getMinimumVersion());
+        } else if (!SlsVersion.check(serviceDependency.getRecommendedVersion())) {
             throw new IllegalArgumentException("recommendedVersion must be valid SLS versions: "
-                    + productDependency.getRecommendedVersion());
-        } else if (productDependency.getMinimumVersion().equals(productDependency.getMaximumVersion())) {
+                    + serviceDependency.getRecommendedVersion());
+        } else if (serviceDependency.getMinimumVersion().equals(serviceDependency.getMaximumVersion())) {
             throw new IllegalArgumentException("minimumVersion and maximumVersion must be different");
         }
     }

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
@@ -249,6 +249,6 @@ class ConjureServiceDependencyTest extends IntegrationSpec {
         def manifestEntry = zf.getEntry("META-INF/MANIFEST.MF")
         def manifest = new Manifest(zf.getInputStream(manifestEntry))
         return manifest.getMainAttributes().getValue(
-                ConjureJavaServiceDependenciesTask.SIS_RECOMMENCED_PRODUCT_DEPS_KEY)
+                ConjureJavaServiceDependenciesTask.SLS_RECOMMENDED_PRODUCT_DEPENDENCIES)
     }
 }

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
@@ -20,7 +20,7 @@ import java.util.jar.Manifest
 import java.util.zip.ZipFile
 import nebula.test.IntegrationSpec
 
-class ConjureProductDependencyTest extends IntegrationSpec {
+class ConjureServiceDependencyTest extends IntegrationSpec {
 
     def setup() {
         addSubproject('api')
@@ -97,17 +97,17 @@ class ConjureProductDependencyTest extends IntegrationSpec {
 
     def "generates empty product dependencies if not configured"() {
         when:
-        runTasksSuccessfully(":api:generateConjureProductDependency")
+        runTasksSuccessfully(':api:generateConjureServiceDependencies')
 
         then:
-        fileExists("api/build/product-dependencies.json")
-        file('api/build/product-dependencies.json').text == '[]'
+        fileExists("api/build/service-dependencies.json")
+        file('api/build/service-dependencies.json').text == '[]'
     }
 
     def "generates product dependencies if extension is configured"() {
         file('api/build.gradle') << '''
-        productDependencies {
-            productDependency {
+        serviceDependencies {
+            serviceDependency {
                 productGroup = "com.palantir.conjure"
                 productName = "conjure"
                 minimumVersion = "1.2.0"
@@ -117,21 +117,21 @@ class ConjureProductDependencyTest extends IntegrationSpec {
         }
         '''.stripIndent()
         when:
-        runTasksSuccessfully(':api:generateConjureProductDependency')
+        runTasksSuccessfully(':api:generateConjureServiceDependencies')
 
         then:
-        fileExists('api/build/product-dependencies.json')
-        file('api/build/product-dependencies.json').text.contains('"product-group":"com.palantir.conjure"')
-        file('api/build/product-dependencies.json').text.contains('"product-name":"conjure"')
-        file('api/build/product-dependencies.json').text.contains('"minimum-version":"1.2.0"')
-        file('api/build/product-dependencies.json').text.contains('"maximum-version":"2.x.x"')
-        file('api/build/product-dependencies.json').text.contains('"recommended-version":"1.2.0"')
+        fileExists('api/build/service-dependencies.json')
+        file('api/build/service-dependencies.json').text.contains('"product-group":"com.palantir.conjure"')
+        file('api/build/service-dependencies.json').text.contains('"product-name":"conjure"')
+        file('api/build/service-dependencies.json').text.contains('"minimum-version":"1.2.0"')
+        file('api/build/service-dependencies.json').text.contains('"maximum-version":"2.x.x"')
+        file('api/build/service-dependencies.json').text.contains('"recommended-version":"1.2.0"')
     }
 
     def "correctly passes product dependencies to generators"() {
         file('api/build.gradle') << '''
-        productDependencies {
-            productDependency {
+        serviceDependencies {
+            serviceDependency {
                 productGroup = "com.palantir.conjure"
                 productName = "conjure"
                 minimumVersion = "1.2.0"
@@ -144,14 +144,14 @@ class ConjureProductDependencyTest extends IntegrationSpec {
         def result = runTasksSuccessfully(':api:compileConjure')
 
         then:
-        result.wasExecuted(':api:generateConjureProductDependency')
+        result.wasExecuted(':api:generateConjureServiceDependencies')
         file('api/api-typescript/src/package.json').text.contains('sls')
     }
 
     def "does not pass product dependencies to java objects"() {
          file('api/build.gradle') << '''
-        productDependencies {
-            productDependency {
+        serviceDependencies {
+            serviceDependency {
                 productGroup = "com.palantir.conjure"
                 productName = "conjure"
                 minimumVersion = "1.2.0"
@@ -164,14 +164,14 @@ class ConjureProductDependencyTest extends IntegrationSpec {
         def result = runTasksSuccessfully(':api:api-objects:Jar')
 
         then:
-        !result.wasExecuted(':api:generateConjureProductDependency')
+        !result.wasExecuted(':api:generateConjureServiceDependencies')
         readRecommendedProductDeps(file('api/api-objects/build/libs/api-objects-0.1.0.jar')) == null
     }
 
     def "correctly configures manifest for java jersey"() {
         file('api/build.gradle') << '''
-        productDependencies {
-            productDependency {
+        serviceDependencies {
+            serviceDependency {
                 productGroup = "com.palantir.conjure"
                 productName = "conjure"
                 minimumVersion = "1.2.0"
@@ -184,7 +184,7 @@ class ConjureProductDependencyTest extends IntegrationSpec {
         def result = runTasksSuccessfully(':api:api-jersey:Jar')
 
         then:
-        result.wasExecuted(':api:generateConjureProductDependency')
+        result.wasExecuted(':api:generateConjureServiceDependencies')
         def recommendedDeps = readRecommendedProductDeps(file('api/api-jersey/build/libs/api-jersey-0.1.0.jar'))
         recommendedDeps == '{"recommended-product-dependencies":[{' +
                 '"product-group":"com.palantir.conjure",' +
@@ -196,8 +196,8 @@ class ConjureProductDependencyTest extends IntegrationSpec {
 
     def "fails on absent fields"() {
         file('api/build.gradle') << '''
-        productDependencies {
-            productDependency {
+        serviceDependencies {
+            serviceDependency {
                 productName = "conjure"
                 minimumVersion = "1.2.0"
                 recommendedVersion = "1.2.0"
@@ -207,13 +207,13 @@ class ConjureProductDependencyTest extends IntegrationSpec {
         '''.stripIndent()
 
         expect:
-        runTasksWithFailure(':generateConjureProductDependency')
+        runTasksWithFailure(':api:generateConjureServiceDependencies')
     }
 
     def "fails on invalid version"() {
         file('api/build.gradle') << '''
-        productDependencies {
-            productDependency {
+        serviceDependencies {
+            serviceDependency {
                 productGroup = "com.palantir.conjure"
                 productName = "conjure"
                 minimumVersion = "1.x.0"
@@ -224,13 +224,13 @@ class ConjureProductDependencyTest extends IntegrationSpec {
         '''.stripIndent()
 
         expect:
-        runTasksWithFailure(':generateConjureProductDependency')
+        runTasksWithFailure(':api:generateConjureServiceDependencies')
     }
 
     def "fails on invalid group"() {
         file('api/build.gradle') << '''
-        productDependencies {
-            productDependency {
+        serviceDependencies {
+            serviceDependency {
                 productGroup = "com.palantir:conjure"
                 productName = "conjure"
                 minimumVersion = "1.0.0"
@@ -241,7 +241,7 @@ class ConjureProductDependencyTest extends IntegrationSpec {
         '''.stripIndent()
 
         expect:
-        runTasksWithFailure(':generateConjureProductDependency')
+        runTasksWithFailure(':api:generateConjureServiceDependencies')
     }
 
     def readRecommendedProductDeps(File jarFile) {
@@ -249,6 +249,6 @@ class ConjureProductDependencyTest extends IntegrationSpec {
         def manifestEntry = zf.getEntry("META-INF/MANIFEST.MF")
         def manifest = new Manifest(zf.getInputStream(manifestEntry))
         return manifest.getMainAttributes().getValue(
-                ConjureJavaProductDependenciesTask.SLS_RECCOMENDED_PRODUCT_DEPS_KEY)
+                ConjureJavaServiceDependenciesTask.SIS_RECOMMENCED_PRODUCT_DEPS_KEY)
     }
 }


### PR DESCRIPTION
## Before this PR
Exposed a `productDependencies` extension which allow you to define a set of `productDependency` 
ex.

```
productDependencies {
  productDependency {
    productGroup = "com.palantir.conjure"
    productName = "conjure"
    minimumVersion = "1.2.0"
    recommendedVersion = "1.2.0"
    maximumVersion = "2.x.x"
  }
}
```

## After this PR
Renamed extensions to more closely align with the conjure model of objects and services.
ex.
```
serviceDependencies {
  serviceDependency {
    productGroup = "com.palantir.conjure"
    productName = "conjure"
    minimumVersion = "1.2.0"
    recommendedVersion = "1.2.0"
    maximumVersion = "2.x.x"
  }
}
```

Open Question: 
Should we follow up with `conjure-typescript` to push the refactor further?
