### PR TITLE
[fix] Restore gitignore contents

### DIFF
--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -66,7 +66,7 @@ public final class ConjurePlugin implements Plugin<Project> {
     static final String JAVA_JERSEY_SUFFIX = "-jersey";
     static final String JAVA_RETROFIT_SUFFIX = "-retrofit";
     static final String JAVA_GENERATED_SOURCE_DIRNAME = "src/generated/java";
-    static final String JAVA_GITIGNORE_CONTENTS = "/src/generated/java/\n/src/main/resources/\n";
+    static final String JAVA_GITIGNORE_CONTENTS = "/src/generated/java/\n";
 
     private final org.gradle.api.internal.file.SourceDirectorySetFactory sourceDirectorySetFactory;
 

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -124,7 +124,7 @@ class ConjurePluginTest extends IntegrationSpec {
         fileExists('api/api-objects/src/generated/java/test/test/api/StringExample.java')
         file('api/api-objects/src/generated/java/test/test/api/StringExample.java').text.contains('ignoreUnknown')
         fileExists('api/api-objects/.gitignore')
-        file('api/api-objects/.gitignore').readLines() == ['/src/generated/java/', '/src/main/resources/']
+        file('api/api-objects/.gitignore').readLines() == ['/src/generated/java/']
 
         // typescript
         fileExists('api/api-typescript/src/api/index.ts')


### PR DESCRIPTION
The https://github.com/palantir/gradle-conjure/pull/54 changed the contents of `src/.gitignore`, but the change was actually unnecessary because we decided to directly change the jar manifest attributes:

```diff
 /src/generated/java/
+/src/main/resources/
```

## After this PR

We go back to the pre #54 behaviour

cc @fsamuel-bs 