### PR TITLE
README mentions serviceDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ conjure {
 
 ### Service dependencies
 
-To help consumers correlate generated Conjure API artifacts with a real server that implements this API, the `com.palantir.conjure` plugin supports embedding optional 'service dependencies' in generated artifacts.
+To help consumers correlate generated Conjure API artifacts with a real server that implements this API, the `com.palantir.conjure` plugin supports embedding optional 'service dependencies' in generated artifacts. (Requires gradle-conjure 4.6.2+.)
 
 This information can be defined using the `serviceDependencies` extension on your API project. You must specify the 'group' and 'name' of the server that implements this API, along with a minimum, maximum and recommended version for the server.
 


### PR DESCRIPTION
This functionality was added in https://github.com/palantir/gradle-conjure/pull/54, but we forgot to document it in the README.