### PR TITLE
[wip] [improvement] Provide default versions for tool dependencies

### DIFF
--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
@@ -146,7 +146,8 @@ public final class ConjureLocalPlugin implements Plugin<Project> {
         Configuration conjurePythonConfig = project.getConfigurations().maybeCreate(ConjurePlugin.CONJURE_PYTHON);
 
         File conjurePythonDir = new File(project.getBuildDir(), ConjurePlugin.CONJURE_PYTHON);
-        project.getDependencies().add(ConjurePlugin.CONJURE_PYTHON, ConjurePlugin.CONJURE_PYTHON_BINARY);
+        conjurePythonConfig.defaultDependencies(
+                deps -> deps.add(project.getDependencies().create(ConjurePlugin.CONJURE_PYTHON_BINARY)));
 
         ExtractExecutableTask extractConjurePythonTask = ExtractExecutableTask.createExtractTask(
                 project,
@@ -180,8 +181,8 @@ public final class ConjureLocalPlugin implements Plugin<Project> {
                 .maybeCreate(ConjurePlugin.CONJURE_TYPESCRIPT);
         File conjureTypescriptDir = new File(project.getBuildDir(), ConjurePlugin.CONJURE_TYPESCRIPT);
         File srcDirectory = subproj.file("src");
-        project.getDependencies().add(
-                ConjurePlugin.CONJURE_TYPESCRIPT, ConjurePlugin.CONJURE_TYPESCRIPT_BINARY);
+        conjureTypeScriptConfig.defaultDependencies(
+                deps -> deps.add(project.getDependencies().create(ConjurePlugin.CONJURE_TYPESCRIPT_BINARY)));
 
         ExtractExecutableTask extractConjureTypeScriptTask = ExtractExecutableTask.createExtractTask(
                 project,

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -194,7 +194,7 @@ public final class ConjurePlugin implements Plugin<Project> {
 
                 ConfigurationContainer configurations = subproj.getConfigurations();
                 subproj.getDependencies().add("compile", "com.palantir.conjure.java:conjure-lib");
-                subproj.getDependencies().add("compileOnly", "javax.annotation:javax.annotation-api:2.0.1");
+                subproj.getDependencies().add("compileOnly", "javax.annotation:javax.annotation-api");
             });
         }
     }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -257,8 +257,8 @@ public final class ConjurePlugin implements Plugin<Project> {
                         productDependencyTask));
                 Task cleanTask = project.getTasks().findByName(TASK_CLEAN);
                 cleanTask.dependsOn(project.getTasks().findByName("cleanCompileConjureRetrofit"));
-                configureJavaSubprojectDependencies(subproj, RETROFIT_2_DEP);
 
+                configureJavaSubprojectDependencies(subproj, RETROFIT_2_DEP);
                 subproj.getDependencies().add("compile", project.findProject(objectsProjectName));
             });
         }
@@ -314,6 +314,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                 cleanTask.dependsOn(project.getTasks().findByName("cleanCompileConjureJersey"));
 
                 configureJavaSubprojectDependencies(subproj, JAX_RS_API_DEP);
+                subproj.getDependencies().add("compile", project.findProject(objectsProjectName));
             });
         }
     }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -59,9 +59,8 @@ public final class ConjurePlugin implements Plugin<Project> {
     // executable distributions
     private static final String CONJURE_COMPILER_BINARY = "com.palantir.conjure:conjure:4.3.0";
     private static final String CONJURE_JAVA_BINARY = "com.palantir.conjure.java:conjure-java:2.4.0";
-    private static final String CONJURE_TYPESCRIPT_BINARY
-            = "com.palantir.conjure.typescript:conjure-typescript:3.3.0@tgz";
-    private static final String CONJURE_PYTHON_BINARY = "com.palantir.conjure.python:conjure-python:3.9.1";
+    static final String CONJURE_TYPESCRIPT_BINARY = "com.palantir.conjure.typescript:conjure-typescript:3.3.0@tgz";
+    static final String CONJURE_PYTHON_BINARY = "com.palantir.conjure.python:conjure-python:3.9.1";
 
     // java project constants
     static final String JAVA_OBJECTS_SUFFIX = "-objects";


### PR DESCRIPTION
## Before this PR

It's hard to set up a gradle project from scratch.
According to the [getting started guide](https://github.com/palantir/conjure/blob/develop/docs/getting_started.md), you have to specify versions for each generator manually, either by 
* replacing the versionless dependencies that are auto-added by gradle-conjure with the same dependency but specifying an actual version
* using `nebula.dependency-recommender` to provide the versions

## After this PR

We are now using [configuration defaults](https://docs.gradle.org/current/userguide/customizing_dependency_resolution_behavior.html#sec:configuration_defaults) which allow you to provide default versions for these tools, whilst allowing you to override them with your own dependencies, ~as well as forcing their versions with nebula~.

TODO:

- [ ] figure out how to allow nebula to force dependencies coming from `defaultDependencies`