### PR TITLE
[improvement] Check java versions are the same with a task

### DIFF
--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CheckConjureJavaVersions.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CheckConjureJavaVersions.java
@@ -20,7 +20,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.MoreCollectors;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.result.ResolutionResult;
@@ -28,17 +27,20 @@ import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.tasks.TaskAction;
 
 public class CheckConjureJavaVersions extends DefaultTask {
-    private Set<String> javaProjectSuffixes;
+
+    public CheckConjureJavaVersions() {
+        setGroup(ConjurePlugin.TASK_GROUP);
+        setDescription("Ensures that conjure-java and conjure-lib versions are identical");
+    }
 
     @TaskAction
     public final void run() {
-        Preconditions.checkNotNull(javaProjectSuffixes, "Plugin error - didn't set javaProjectSuffixes");
         // 1. Figure out what version of conjure-java we resolved
         String conjureJavaVersion = findResolvedVersionOf(
                 getProject(), ConjurePlugin.CONJURE_JAVA, ConjurePlugin.CONJURE_JAVA_BINARY);
 
         // 2. Ensure in each subproject, the version of conjure-lib in `compile` is the same.
-        javaProjectSuffixes.stream()
+        ConjurePlugin.JAVA_PROJECT_SUFFIXES.stream()
                 .map(suffix -> getProject().findProject(getProject().getName() + suffix))
                 .filter(Objects::nonNull)
                 .forEach(subproj -> {
@@ -68,9 +70,5 @@ public class CheckConjureJavaVersions extends DefaultTask {
                         new RuntimeException(String.format("Expected to find %s in %s", moduleId, configuration)))
                 .getModuleVersion()
                 .getVersion();
-    }
-
-    final void setJavaProjectSuffixes(Set<String> javaProjectSuffixes) {
-        this.javaProjectSuffixes = javaProjectSuffixes;
     }
 }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -65,6 +65,8 @@ public final class ConjurePlugin implements Plugin<Project> {
     static final String JAVA_OBJECTS_SUFFIX = "-objects";
     static final String JAVA_JERSEY_SUFFIX = "-jersey";
     static final String JAVA_RETROFIT_SUFFIX = "-retrofit";
+    static final ImmutableSet<String> JAVA_PROJECT_SUFFIXES = ImmutableSet.of(
+            JAVA_OBJECTS_SUFFIX, JAVA_JERSEY_SUFFIX, JAVA_RETROFIT_SUFFIX);
     static final String JAVA_GENERATED_SOURCE_DIRNAME = "src/generated/java";
     static final String JAVA_GITIGNORE_CONTENTS = "/src/generated/java/\n";
 
@@ -132,12 +134,7 @@ public final class ConjurePlugin implements Plugin<Project> {
             ExtractExecutableTask extractJavaTask = ExtractExecutableTask.createExtractTask(
                     project, "extractConjureJava", conjureJavaConfig, conjureJavaDir, "conjure-java");
 
-            // Set up task to ensure that conjure-java and conjure-lib versions are identical.
-            Task checkVersions = project
-                    .getTasks()
-                    .create("checkConjureJavaVersions",
-                            CheckConjureJavaVersions.class,
-                            task -> task.setJavaProjectSuffixes(javaProjectSuffixes));
+            Task checkVersions = project.getTasks().create("checkConjureJavaVersions", CheckConjureJavaVersions.class);
             extractJavaTask.dependsOn(checkVersions);
 
             setupConjureObjectsProject(


### PR DESCRIPTION
## Before this PR

You could force `com.palantir.conjure.java` dependencies to different versions and you might get a runtime break:

*  `com.palantir.conjure.java:conjure-java` (the [conjure java generator](https://github.com/palantir/conjure-java))
*  `com.palantir.conjure.java:conjure-lib` (runtime libraries required by code generated by the conjure java generator)

## After this PR

There is a task `checkConjureJavaVersions` that looks through the versions of these two artifacts and fails if they are not the same.
This task is a dependency of `extractConjureJava` so will run any time users would try to compile conjure java.