### PR TITLE
[fix] compileConjureJersey is now cacheable

### DIFF
--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureGeneratorTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureGeneratorTask.java
@@ -23,6 +23,8 @@ import java.io.File;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+import org.gradle.api.Action;
+import org.gradle.api.Task;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.OutputDirectory;
@@ -35,8 +37,13 @@ public class ConjureGeneratorTask extends SourceTask {
 
     public ConjureGeneratorTask() {
         // @TaskAction uses doFirst I think, because other actions prepended using doFirst end up happening AFTER the
-        // main task
-        doLast(task -> this.compileFiles());
+        // main task. Intentionally not using a lambda because this breaks Gradle caching
+        doLast(new Action<Task>() {
+            @Override
+            public void execute(Task task) {
+                compileFiles();
+            }
+        });
     }
 
     public final void setOutputDirectory(File outputDirectory) {


### PR DESCRIPTION
## Before this PR

Running `./gradlew jar` multiple times would always re-invoke conjure-java, despite no changes to sources or outputs.

<img width="957" alt="screen shot 2019-02-12 at 14 14 59" src="https://user-images.githubusercontent.com/3473798/52641379-9cc8ee80-2ed0-11e9-99e3-20d31359d12c.png">


## After this PR

Local development will be much snappier. Things should say 'UP-TO-DATE'.

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
