### PR TITLE
[improvement] Configure Conjure Java Jar at configuration time

### DIFF
--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaServiceDependencies.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaServiceDependencies.java
@@ -24,14 +24,19 @@ import java.util.Set;
 import org.gradle.api.Project;
 import org.gradle.jvm.tasks.Jar;
 
-public final class ConjureJavaServiceDependencies {
+final class ConjureJavaServiceDependencies {
     public static final String SLS_RECOMMENDED_PRODUCT_DEPENDENCIES = "Sls-Recommended-Product-Dependencies";
 
     private ConjureJavaServiceDependencies() {}
 
+    /*
+     * We directly configure the Jar task instead of using the generated product-dependencies.json since we use gradle
+     * to produce Jars which the Java generator is not aware of.
+     */
     static void configureJavaServiceDependencies(
             Project project, ConjureProductDependenciesExtension productDependencyExt)  {
 
+        // HACKHACK Jar does not expose a lazy mechanism for configuring attributes so we have to do it after evaluation
         project.afterEvaluate(p -> p.getTasks().withType(Jar.class, jar -> {
             Set<ServiceDependency> productDependencies = productDependencyExt.getProductDependencies();
 

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureJavaServiceDependencyProjectSpec.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureJavaServiceDependencyProjectSpec.groovy
@@ -1,0 +1,67 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.conjure
+
+import com.palantir.gradle.conjure.api.ConjureProductDependenciesExtension
+import nebula.test.ProjectSpec
+import org.gradle.jvm.tasks.Jar
+
+class ConjureJavaServiceDependencyProjectSpec extends ProjectSpec {
+    Jar jar
+
+    def setup() {
+        jar = project.tasks.create("jar", Jar.class)
+    }
+
+    def "generates empty product dependencies if not configured"() {
+        given:
+        ConjureJavaServiceDependencies.configureJavaServiceDependencies(project, new ConjureProductDependenciesExtension())
+
+        when:
+        project.evaluate()
+
+        then:
+        jar.manifest.attributes[ConjureJavaServiceDependencies.SLS_RECOMMENDED_PRODUCT_DEPENDENCIES] == '{"recommended-product-dependencies":[]}'
+    }
+
+    def "generates product dependencies if extension is configured"() {
+        given:
+        def ext = new ConjureProductDependenciesExtension()
+        ext.serviceDependency {
+            productGroup = "com.palantir.conjure"
+            productName = "conjure"
+            minimumVersion = "1.2.0"
+            recommendedVersion = "1.2.0"
+            maximumVersion = "2.x.x"
+        }
+        ConjureJavaServiceDependencies.configureJavaServiceDependencies(project, ext)
+
+        when:
+        project.evaluate()
+
+        then:
+        jar.manifest.attributes[ConjureJavaServiceDependencies.SLS_RECOMMENDED_PRODUCT_DEPENDENCIES] == ''+
+                '{"recommended-product-dependencies":[{' +
+                '"product-group":"com.palantir.conjure",' +
+                '"product-name":"conjure",' +
+                '"minimum-version":"1.2.0",' +
+                '"maximum-version":"2.x.x",' +
+                '"recommended-version":"1.2.0"' +
+                '}]}'
+    }
+
+}

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
@@ -184,7 +184,7 @@ class ConjureServiceDependencyTest extends IntegrationSpec {
         def result = runTasksSuccessfully(':api:api-jersey:Jar')
 
         then:
-        result.wasExecuted(':api:generateConjureServiceDependencies')
+        !result.wasExecuted(':api:generateConjureServiceDependencies')
         def recommendedDeps = readRecommendedProductDeps(file('api/api-jersey/build/libs/api-jersey-0.1.0.jar'))
         recommendedDeps == '{"recommended-product-dependencies":[{' +
                 '"product-group":"com.palantir.conjure",' +
@@ -249,6 +249,6 @@ class ConjureServiceDependencyTest extends IntegrationSpec {
         def manifestEntry = zf.getEntry("META-INF/MANIFEST.MF")
         def manifest = new Manifest(zf.getInputStream(manifestEntry))
         return manifest.getMainAttributes().getValue(
-                ConjureJavaServiceDependenciesTask.SLS_RECOMMENDED_PRODUCT_DEPENDENCIES)
+                ConjureJavaServiceDependencies.SLS_RECOMMENDED_PRODUCT_DEPENDENCIES)
     }
 }


### PR DESCRIPTION
## Before this PR
We used a task to configure the service dependencies of Jars

## After this PR
We configure the service dependencies at configuration time.

This change was made to make it easier to reason about when service dependencies would exist on Jar tasks
