### PR TITLE
[improvement] Stop using lambda in doFirst to improve build caching

### DIFF
--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.function.Supplier;
 import javax.inject.Inject;
+import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -538,8 +539,13 @@ public final class ConjurePlugin implements Plugin<Project> {
         Copy copyConjureSourcesTask = project.getTasks().create("copyConjureSourcesIntoBuild", Copy.class);
         copyConjureSourcesTask.into(project.file(buildDir)).from(conjureSourceSet);
 
-        copyConjureSourcesTask.doFirst(task -> {
-            GFileUtils.deleteDirectory(buildDir);
+        // Replacing this with a lambda is not supported for build caching
+        // (see https://github.com/gradle/gradle/issues/5510)
+        copyConjureSourcesTask.doFirst(new Action<Task>() {
+            @Override
+            public void execute(Task task) {
+                GFileUtils.deleteDirectory(buildDir);
+            }
         });
 
         Task cleanTask = project.getTasks().findByName(TASK_CLEAN);


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->
Copying conjure sources was not cacheable because gradle does not (currently) support Java lambdas: https://github.com/gradle/gradle/issues/5510

bluf of the issue: Java lambdas do not reproducibly generate the same ID internally, so gradle is unable to determine if the lambda has changed. The easy fix is to just use an anonymous function until gradle fixes this upstream.

## After this PR
<!-- Describe at a high-level why this approach is better. -->
Copying conjure sources is now cacheable
<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
relevant to https://github.com/gradle/gradle/issues/5510