### PR TITLE
[improvement] All tasks are now compatible with the Gradle Build Cache

### DIFF
--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileConjurePythonTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileConjurePythonTask.java
@@ -24,8 +24,10 @@ import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
 
+@CacheableTask
 public class CompileConjurePythonTask extends ConjureGeneratorTask {
 
     @Override

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileConjureTypeScriptTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileConjureTypeScriptTask.java
@@ -23,14 +23,19 @@ import java.util.function.Supplier;
 import org.gradle.api.Action;
 import org.gradle.api.Task;
 import org.gradle.api.file.ConfigurableFileTree;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 
+@CacheableTask
 public class CompileConjureTypeScriptTask extends ConjureGeneratorTask {
 
     private File productDependencyFile;
 
     @InputFile
+    @PathSensitive(PathSensitivity.NONE)
     public final File getProductDependencyFile() {
         return productDependencyFile;
     }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
@@ -69,7 +69,7 @@ public class CompileIrTask extends DefaultTask {
         getProject().exec(execSpec -> {
             ImmutableList.Builder<String> commandArgsBuilder = ImmutableList.builder();
             commandArgsBuilder.add(
-                    executableDir.get().toPath().resolve("bin").resolve("conjure").toFile().getAbsolutePath(),
+                    new File(executableDir.get(), "bin/conjure").getAbsolutePath(),
                     "compile",
                     inputDirectory.get().getAbsolutePath(),
                     outputFile.getAbsolutePath());

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
@@ -21,16 +21,19 @@ import java.io.File;
 import java.util.List;
 import java.util.function.Supplier;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.InputDirectory;
-import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 
+@CacheableTask
 public class CompileIrTask extends DefaultTask {
 
     private File outputFile;
     private Supplier<File> inputDirectory;
-    private Supplier<File> executablePath;
+    private Supplier<File> executableDir;
 
     public final void setOutputFile(File outputFile) {
         this.outputFile = outputFile;
@@ -46,17 +49,19 @@ public class CompileIrTask extends DefaultTask {
     }
 
     @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
     public final File getInputDirectory() {
         return inputDirectory.get();
     }
 
-    public final void setExecutablePath(Supplier<File> executablePath) {
-        this.executablePath = executablePath;
+    public final void setExecutableDir(Supplier<File> executableDir) {
+        this.executableDir = executableDir;
     }
 
-    @InputFile
-    public final File getExecutablePath() {
-        return executablePath.get();
+    @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public final File getExecutableDir() {
+        return executableDir.get();
     }
 
     @TaskAction
@@ -64,7 +69,7 @@ public class CompileIrTask extends DefaultTask {
         getProject().exec(execSpec -> {
             ImmutableList.Builder<String> commandArgsBuilder = ImmutableList.builder();
             commandArgsBuilder.add(
-                    executablePath.get().getAbsolutePath(),
+                    executableDir.get().toPath().resolve("bin").resolve("conjure").toFile().getAbsolutePath(),
                     "compile",
                     inputDirectory.get().getAbsolutePath(),
                     outputFile.getAbsolutePath());

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureGeneratorTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureGeneratorTask.java
@@ -25,11 +25,15 @@ import java.util.Map;
 import java.util.function.Supplier;
 import org.gradle.api.Action;
 import org.gradle.api.Task;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SourceTask;
 
+@CacheableTask
 public class ConjureGeneratorTask extends SourceTask {
     private Supplier<File> executablePathSupplier;
     private File outputDirectory;
@@ -60,6 +64,7 @@ public class ConjureGeneratorTask extends SourceTask {
     }
 
     @InputFile
+    @PathSensitive(PathSensitivity.NONE)
     public final File getExecutablePath() {
         return executablePathSupplier.get();
     }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalGenerateTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalGenerateTask.java
@@ -17,7 +17,9 @@
 package com.palantir.gradle.conjure;
 
 import java.io.File;
+import org.gradle.api.tasks.CacheableTask;
 
+@CacheableTask
 public class ConjureLocalGenerateTask extends ConjureGeneratorTask {
 
     @Override

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -529,7 +529,7 @@ public final class ConjurePlugin implements Plugin<Project> {
             compileIr.setDescription("Converts your Conjure YML files into a single portable JSON file in IR format.");
             compileIr.setGroup(TASK_GROUP);
             compileIr.setInputDirectory(copyConjureSourcesTask::getDestinationDir);
-            compileIr.setExecutablePath(extractCompilerTask::getExecutable);
+            compileIr.setExecutableDir(extractCompilerTask::getOutputDirectory);
             compileIr.setOutputFile(irPath);
             compileIr.dependsOn(copyConjureSourcesTask);
             compileIr.dependsOn(extractCompilerTask);


### PR DESCRIPTION
## Before this PR

Using gradle enterprise, I noticed that a decent chunk of time on every CI build is spent re-running our conjure generators.  These are particularly slow because we require the abstraction of a tgz, so we pay the price of a JVM startup.

## After this PR
==COMMIT_MSG==
./gradlew compileConjure is now compatible with the build cache
==COMMIT_MSG==

This should mean that after a `git clean -xdf` (or switched local branches), a second run of `./gradlew compileConjure` should be _much_ faster, with lots of tasks showing `FROM-CACHE`. Retriggered builds on CI should also be faster.

## Possible downsides?
If someone implements a generator that is not deterministic, this might give them confusing behaviour.  Also, if don't declare inputs correctly then this functionality might annoy users who change source files but don't see their tasks re-run. Thankfully, using `--rerun-tasks` is an easy workaround here