### PR TITLE
[improvement] Allow -jaxrs suffix

### DIFF
--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -328,7 +328,7 @@ class ConjurePluginTest extends IntegrationSpec {
         apply plugin: 'nebula.source-jar'
 
         dependencies {
-            compile project(':api:api-jersey')
+            compile project(':api:api-jaxrs')
             compile project(':api:api-retrofit') // safe to include both this and jersey, if necessary
         }
         '''.stripIndent()
@@ -337,16 +337,16 @@ class ConjurePluginTest extends IntegrationSpec {
         ExecutionResult result = runTasksSuccessfully('--parallel', 'publishToMavenLocal')
 
         then:
-        result.wasExecuted(':api:api-jersey:compileJava')
+        result.wasExecuted(':api:api-jaxrs:compileJava')
         result.wasExecuted(':api:compileConjureJersey')
 
         new File(System.getProperty('user.home') + '/.m2/repository/com/palantir/conjure/test/').exists()
         new File(System.getProperty('user.home') +
-                '/.m2/repository/com/palantir/conjure/test/api-jersey/0.1.0/api-jersey-0.1.0.pom').exists()
+                '/.m2/repository/com/palantir/conjure/test/api-jaxrs/0.1.0/api-jaxrs-0.1.0.pom').exists()
         new File(System.getProperty('user.home') +
                 '/.m2/repository/com/palantir/conjure/test/server/0.1.0/server-0.1.0.pom').exists()
         new File(System.getProperty('user.home') +
-                '/.m2/repository/com/palantir/conjure/test/server/0.1.0/server-0.1.0.pom').text.contains('>api-jersey<')
+                '/.m2/repository/com/palantir/conjure/test/server/0.1.0/server-0.1.0.pom').text.contains('>api-jaxrs<')
     }
 
     def 'copies conjure imports into build directory and provides imports to conjure compiler'() {


### PR DESCRIPTION
## Before this PR

As part of the migration to undertow, people are getting slightly confused about whether they can use undertow on the client-side and whether they can fully delete the -jersey project.

-jersey is actually not quite right because it only has jaxrs annotations (e.g. `@Path`, `@GET` etc), which is why it _does_ work on both the client-side and the server-side!

## After this PR
==COMMIT_MSG==
Naming a project :foo-jaxrs will now get the same codegen as :foo-jersey
==COMMIT_MSG==

## Possible downsides?

It's a bit hacktastic, haven't renamed everything under the hood yet.