### PR TITLE
[improvement] support conjure-java in local plugin

### DIFF
--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -471,12 +471,12 @@ public final class ConjurePlugin implements Plugin<Project> {
         }
     }
 
-    private static void addGeneratedToMainSourceSet(Project subproj) {
+    static void addGeneratedToMainSourceSet(Project subproj) {
         JavaPluginConvention javaPlugin = subproj.getConvention().findPlugin(JavaPluginConvention.class);
         javaPlugin.getSourceSets().getByName("main").getJava().srcDir(subproj.files(JAVA_GENERATED_SOURCE_DIRNAME));
     }
 
-    private static void applyDependencyForIdeTasks(Project project, Task compileConjure) {
+    static void applyDependencyForIdeTasks(Project project, Task compileConjure) {
         project.getPlugins().withType(IdeaPlugin.class, plugin -> {
             Task task = project.getTasks().findByName("ideaModule");
             if (task != null) {
@@ -504,7 +504,7 @@ public final class ConjurePlugin implements Plugin<Project> {
         });
     }
 
-    private static Task createWriteGitignoreTask(Project project, String taskName, File outputDir, String contents) {
+    static Task createWriteGitignoreTask(Project project, String taskName, File outputDir, String contents) {
         WriteGitignoreTask writeGitignoreTask = project.getTasks().create(taskName, WriteGitignoreTask.class);
         writeGitignoreTask.setOutputDirectory(outputDir);
         writeGitignoreTask.setContents(contents);

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalPluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalPluginTest.groovy
@@ -38,6 +38,7 @@ class ConjureLocalPluginTest extends IntegrationSpec {
             configurations.all {
                resolutionStrategy {
                    failOnVersionConflict()
+                   force 'com.palantir.conjure.java:conjure-java:3.10.0'
                    force 'com.palantir.conjure.typescript:conjure-typescript:3.1.1'
                    force 'com.palantir.conjure.python:conjure-python:3.9.0'
                    force 'com.palantir.conjure:conjure:4.0.0'
@@ -55,6 +56,25 @@ class ConjureLocalPluginTest extends IntegrationSpec {
 
     def setup() {
         buildFile << standardBuildFile
+    }
+
+    def "generates java code"() {
+        addSubproject("java")
+        buildFile << """
+        conjure {
+          java {
+            objects = true 
+          }
+        }
+        """.stripIndent()
+
+        when:
+        ExecutionResult result = runTasksSuccessfully("generateConjure")
+
+        then:
+        result.wasExecuted(":generateJava")
+
+        fileExists('java/src/generated/java/com/palantir/conjure/spec/ConjureDefinition.java')
     }
 
     def "generateConjure generates code in subprojects"() {


### PR DESCRIPTION
## Before this PR
We did not support Java as a first class language within `com.palantir.conjure-local`. Users would be surprised to find that the `java` section of the `conjure` extension was ignored and the only was to generate java code was to use the generic generator config, ex:
```gradle
conjure {
    options "java", {
      ...
    }
}
```

## After this PR
==COMMIT_MSG==
Add basic support for conjure-java in `com.palantir.conjure-local`
==COMMIT_MSG==

Since `conjure-java` requires a flag to be passed to specify what category of code to generate, it does not work out of the box.  Instead, users will have to do the following:
```gradle
conjure {
    java {
        // One of the following
        objects = true
        jersey = true
        retrofit = true
        undertow = true
    }
}
```

We can fix this by updating `conjure-java` to support multiple flags being passed at once. 

## Possible downsides?
Local code-gen is fully supported and will have rough edges that users can run into. In particular, I'm concerned about the danger of duplicate classes if a library uses this plugin and loss of automatic product dependencies.
