### PR TITLE
[improvement] support generic generator for API producers

### DIFF
--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
@@ -35,20 +35,17 @@ import org.gradle.util.GUtil;
 
 public final class ConjureLocalPlugin implements Plugin<Project> {
     private static final String CONJURE_CONFIGURATION = "conjure";
-    /** Configuration where custom generators should be added as dependencies. */
-    private static final String CONJURE_GENERATORS_CONFIGURATION_NAME = "conjureGenerators";
 
     private static final String PYTHON_PROJECT_NAME = "python";
     private static final String TYPESCRIPT_PROJECT_NAME = "typescript";
     private static final ImmutableSet<String> FIRST_CLASS_GENERATOR_PROJECT_NAMES = ImmutableSet.of(
             PYTHON_PROJECT_NAME, TYPESCRIPT_PROJECT_NAME);
-    private static final String CONJURE_GENERATOR_DEP_PREFIX = "conjure-";
 
     @Override
     public void apply(Project project) {
         Configuration conjureIrConfiguration = project.getConfigurations().maybeCreate(CONJURE_CONFIGURATION);
         Configuration conjureGeneratorsConfiguration = project.getConfigurations().maybeCreate(
-                CONJURE_GENERATORS_CONFIGURATION_NAME);
+                ConjurePlugin.CONJURE_GENERATORS_CONFIGURATION_NAME);
 
         ConjureExtension extension = project.getExtensions()
                 .create(ConjureExtension.EXTENSION_NAME, ConjureExtension.class);
@@ -79,11 +76,12 @@ public final class ConjureLocalPlugin implements Plugin<Project> {
                     .getAllDependencies()
                     .stream()
                     .collect(Collectors.toMap(dependency -> {
-                        Preconditions.checkState(dependency.getName().startsWith(CONJURE_GENERATOR_DEP_PREFIX),
+                        Preconditions.checkState(dependency.getName().startsWith(
+                                ConjurePlugin.CONJURE_GENERATOR_DEP_PREFIX),
                                 "Generators should start with '%s' according to conjure RFC 002, "
                                         + "but found name: '%s' (%s)",
-                                CONJURE_GENERATOR_DEP_PREFIX, dependency.getName(), dependency);
-                        return dependency.getName().substring(CONJURE_GENERATOR_DEP_PREFIX.length());
+                                ConjurePlugin.CONJURE_GENERATOR_DEP_PREFIX, dependency.getName(), dependency);
+                        return dependency.getName().substring(ConjurePlugin.CONJURE_GENERATOR_DEP_PREFIX.length());
                     }, Function.identity()));
 
             project.getChildProjects().entrySet().stream()
@@ -94,7 +92,7 @@ public final class ConjureLocalPlugin implements Plugin<Project> {
                         if (!generators.containsKey(subprojectName)) {
                             throw new RuntimeException(String.format("Discovered subproject %s without corresponding "
                                             + "generator dependency with name '%s'",
-                                    subproject.getPath(), CONJURE_GENERATOR_DEP_PREFIX + subprojectName));
+                                    subproject.getPath(), ConjurePlugin.CONJURE_GENERATOR_DEP_PREFIX + subprojectName));
                         }
                     });
         });
@@ -107,7 +105,7 @@ public final class ConjureLocalPlugin implements Plugin<Project> {
 
                     // We create a lazy filtered FileCollection to avoid using afterEvaluate.
                     FileCollection matchingGeneratorDeps = conjureGeneratorsConfiguration.fileCollection(
-                            dep -> dep.getName().equals(CONJURE_GENERATOR_DEP_PREFIX + subprojectName));
+                            dep -> dep.getName().equals(ConjurePlugin.CONJURE_GENERATOR_DEP_PREFIX + subprojectName));
 
                     ExtractExecutableTask extractConjureGeneratorTask = ExtractExecutableTask.createExtractTask(
                             project,

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.conjure;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.gradle.conjure.api.ConjureExtension;
 import com.palantir.gradle.conjure.api.ConjureProductDependenciesExtension;
@@ -23,8 +24,11 @@ import com.palantir.gradle.conjure.api.GeneratorOptions;
 import java.io.File;
 import java.nio.file.Paths;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
@@ -32,6 +36,8 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
@@ -42,6 +48,7 @@ import org.gradle.plugins.ide.eclipse.EclipsePlugin;
 import org.gradle.plugins.ide.idea.IdeaPlugin;
 import org.gradle.plugins.ide.idea.model.IdeaModule;
 import org.gradle.util.GFileUtils;
+import org.gradle.util.GUtil;
 
 public final class ConjurePlugin implements Plugin<Project> {
 
@@ -49,6 +56,9 @@ public final class ConjurePlugin implements Plugin<Project> {
     static final String TASK_CLEAN = "clean";
 
     public static final String CONJURE_IR = "compileIr";
+
+    private static final ImmutableSet<String> FIRST_CLASS_GENERATOR_PROJECT_NAMES = ImmutableSet.of(
+            "objects", "jersey", "retrofit", "undertow", "typescript", "python");
 
     // configuration names
     static final String CONJURE_COMPILER = "conjureCompiler";
@@ -74,6 +84,10 @@ public final class ConjurePlugin implements Plugin<Project> {
 
     static final String CONJURE_JAVA_LIB_DEP = "com.palantir.conjure.java:conjure-lib";
 
+    /** Configuration where custom generators should be added as dependencies. */
+    static final String CONJURE_GENERATORS_CONFIGURATION_NAME = "conjureGenerators";
+    static final String CONJURE_GENERATOR_DEP_PREFIX = "conjure-";
+
     private final org.gradle.api.internal.file.SourceDirectorySetFactory sourceDirectorySetFactory;
 
     @Inject
@@ -88,6 +102,8 @@ public final class ConjurePlugin implements Plugin<Project> {
                 .create(ConjureExtension.EXTENSION_NAME, ConjureExtension.class);
         ConjureProductDependenciesExtension conjureProductDependenciesExtension = project.getExtensions()
                 .create(ConjureProductDependenciesExtension.EXTENSION_NAME, ConjureProductDependenciesExtension.class);
+        Configuration conjureGeneratorsConfiguration = project.getConfigurations().maybeCreate(
+                CONJURE_GENERATORS_CONFIGURATION_NAME);
 
         // Set up conjure compile task
         Task compileConjure = project.getTasks().create("compileConjure", DefaultTask.class);
@@ -119,6 +135,12 @@ public final class ConjurePlugin implements Plugin<Project> {
                 compileConjure,
                 compileIrTask,
                 productDependencyTask);
+        setupGenericConjureProjects(
+                project,
+                conjureExtension::getGenericOptions,
+                compileConjure,
+                compileIrTask,
+                conjureGeneratorsConfiguration);
     }
 
     private static void setupConjureJavaProject(
@@ -471,6 +493,77 @@ public final class ConjurePlugin implements Plugin<Project> {
         }
     }
 
+    private static void setupGenericConjureProjects(
+            Project project,
+            Function<String, GeneratorOptions> getGenericOptions,
+            Task compileConjure,
+            Task compileIrTask,
+            Configuration conjureGeneratorsConfiguration) {
+        // Validating that each subproject has a corresponding generator.
+        // We do this in afterEvaluate to ensure the configuration is populated.
+        project.afterEvaluate(p -> {
+            Map<String, Dependency> generators = conjureGeneratorsConfiguration
+                    .getAllDependencies()
+                    .stream()
+                    .collect(Collectors.toMap(dependency -> {
+                        Preconditions.checkState(dependency.getName().startsWith(CONJURE_GENERATOR_DEP_PREFIX),
+                                "Generators should start with '%s' according to conjure RFC 002, "
+                                        + "but found name: '%s' (%s)",
+                                CONJURE_GENERATOR_DEP_PREFIX, dependency.getName(), dependency);
+                        return dependency.getName().substring(CONJURE_GENERATOR_DEP_PREFIX.length());
+                    }, Function.identity()));
+
+            project.getChildProjects().entrySet().stream()
+                    .forEach(entry -> {
+                        String subprojectName = entry.getKey();
+                        Project subproject = entry.getValue();
+                        String conjureLanguage = extractSubprojectLanguage(project.getName(), subprojectName);
+                        if (!FIRST_CLASS_GENERATOR_PROJECT_NAMES.contains(conjureLanguage)
+                                && !generators.containsKey(conjureLanguage)) {
+                            throw new RuntimeException(String.format("Discovered subproject %s without corresponding "
+                                            + "generator dependency with name '%s'",
+                                    subproject.getPath(), ConjurePlugin.CONJURE_GENERATOR_DEP_PREFIX + subprojectName));
+                        }
+                    });
+        });
+
+        project.getChildProjects().entrySet().stream()
+                .filter(e -> FIRST_CLASS_GENERATOR_PROJECT_NAMES.stream()
+                        .noneMatch(l -> l.equals(e.getKey().substring(project.getName().length() + 1))))
+                .forEach(e -> {
+                    String subprojectName = e.getKey();
+                    Project subproject = e.getValue();
+                    String conjureLanguage = extractSubprojectLanguage(project.getName(), subprojectName);
+
+                    // We create a lazy filtered FileCollection to avoid using afterEvaluate.
+                    FileCollection matchingGeneratorDeps = conjureGeneratorsConfiguration.fileCollection(
+                            dep -> dep.getName().equals(CONJURE_GENERATOR_DEP_PREFIX + conjureLanguage));
+
+                    ExtractExecutableTask extractConjureGeneratorTask = ExtractExecutableTask.createExtractTask(
+                            project,
+                            GUtil.toLowerCamelCase("extractConjure " + conjureLanguage),
+                            matchingGeneratorDeps,
+                            new File(subproject.getBuildDir(), "generator"),
+                            String.format("conjure-%s", conjureLanguage));
+
+                    ConjureGeneratorTask conjureLocalGenerateTask = project.getTasks()
+                            .create(GUtil.toLowerCamelCase("compile conjure " + conjureLanguage),
+                                    ConjureGeneratorTask.class,
+                                    task -> {
+                                        task.setDescription(String.format(
+                                                "Generates %s files from remote Conjure definitions.",
+                                                conjureLanguage));
+                                        task.setGroup(ConjurePlugin.TASK_GROUP);
+                                        task.setSource(compileIrTask);
+                                        task.setExecutablePath(extractConjureGeneratorTask::getExecutable);
+                                        task.setOptions(() -> getGenericOptions.apply(conjureLanguage));
+                                        task.setOutputDirectory(subproject.file("src"));
+                                        task.dependsOn(extractConjureGeneratorTask);
+                                    });
+                    compileConjure.dependsOn(conjureLocalGenerateTask);
+                });
+    }
+
     private static void addGeneratedToMainSourceSet(Project subproj) {
         JavaPluginConvention javaPlugin = subproj.getConvention().findPlugin(JavaPluginConvention.class);
         javaPlugin.getSourceSets().getByName("main").getJava().srcDir(subproj.files(JAVA_GENERATED_SOURCE_DIRNAME));
@@ -563,5 +656,9 @@ public final class ConjurePlugin implements Plugin<Project> {
 
     private static Supplier<GeneratorOptions> immutableOptionsSupplier(Supplier<GeneratorOptions> supplier) {
         return () -> new GeneratorOptions(supplier.get());
+    }
+
+    private static String extractSubprojectLanguage(String projectName, String subprojectName) {
+        return subprojectName.substring(projectName.length() + 1);
     }
 }


### PR DESCRIPTION
Closes #90 
Closes #100 

## Before this PR
API producers could only generate code using the first class generators (Java, Python, TypeScript)

## After this PR
==COMMIT_MSG==
Add support to `com.palantir.conjure` for generic Conjure generators 
==COMMIT_MSG==

## Possible downsides?
Additional code path to maintain
