### PR TITLE
Fix typo in test name

### DIFF
--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalPluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalPluginTest.groovy
@@ -58,7 +58,7 @@ class ConjureLocalPluginTest extends IntegrationSpec {
         buildFile << standardBuildFile
     }
 
-    def "could generates java code"() {
+    def "could generate java code"() {
         addSubproject("java")
         buildFile << """
         conjure {


### PR DESCRIPTION
`s/could generates/could generate`

## After this PR
==COMMIT_MSG==
Fix typo in test name
==COMMIT_MSG==
