### PR TITLE
[improvement] only configure generic subprojects if they exist

### DIFF
--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -504,6 +504,9 @@ public final class ConjurePlugin implements Plugin<Project> {
                 project.getChildProjects(),
                 key -> !FIRST_CLASS_GENERATOR_PROJECT_NAMES.contains(
                         extractSubprojectLanguage(project.getName(), key)));
+        if (genericSubProjects.isEmpty()) {
+            return;
+        }
 
         // Validating that each subproject has a corresponding generator.
         // We do this in afterEvaluate to ensure the configuration is populated.

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -556,13 +556,24 @@ class ConjurePluginTest extends IntegrationSpec {
 
         when:
         ExecutionResult result = runTasksSuccessfully(':api:compileConjure')
-        println(result.standardOutput)
 
         then:
         result.wasExecuted(':api:compileConjurePostman')
         fileExists('api/api-postman/src/api.postman_collection.json')
         file('api/api-postman/src/api.postman_collection.json').text.contains('"version" : "1.0.0"')
+    }
 
+    def 'generic setup is a no-op if there no generic subprojects'() {
+        given:
+        file('api/build.gradle') << """
+        dependencies {
+            // The following will cause configuration to fail
+            conjureGenerators 'com.google.guava:guava'
+        }
+        """.stripIndent()
+
+        expect:
+        runTasksSuccessfully('compileConjure')
     }
 
     @Unroll


### PR DESCRIPTION
## Before this PR
We would validate the generic generator configuration even if there were no generic subprojects

## After this PR
==COMMIT_MSG==
Only configure generic subprojects if they exist
==COMMIT_MSG==

## Possible downsides?
N/A