### PR TITLE
[improvement] use genericLocalGenerateGenericTask for Java

### DIFF
--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
@@ -95,7 +95,7 @@ public final class ConjureLocalPlugin implements Plugin<Project> {
         Task gitignoreConjureJava = ConjurePlugin.createWriteGitignoreTask(
                 subproj, "gitignoreConjureJava", subproj.getProjectDir(), ConjurePlugin.JAVA_GITIGNORE_CONTENTS);
 
-        project.getTasks().create("generateJava", ConjureGeneratorTask.class, task -> {
+        project.getTasks().create("generateJava", ConjureLocalGenerateGenericTask.class, task -> {
             task.setDescription("Generates Java bindings for remote Conjure definitions.");
             task.setGroup(ConjurePlugin.TASK_GROUP);
             // TODO(forozco): Automatically pass which category of code to generate

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalPluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalPluginTest.groovy
@@ -74,7 +74,7 @@ class ConjureLocalPluginTest extends IntegrationSpec {
 
         then:
         result.wasExecuted(":generateJava")
-        result.standardOutput.contains('Running generator with args: [--dialog]')
+        result.standardOutput.contains('Running generator with args: [--dialog')
     }
 
     def "fails to generate java with unsafe options"() {


### PR DESCRIPTION
## Before this PR
We did not automatically pass any arguments to the java generator during local codegen

## After this PR
Use `genericLocalGenerateGenericTask` for local Java codegen to automatically pass the productName and productVersion to the generator. @uschi2000 for SA
==COMMIT_MSG==
Pass productName and productVersion to local Java generator
==COMMIT_MSG==

## Possible downsides?
N/A