### PR TITLE
[improvement] Support conjure generation on windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ build:
 build_script:
   - node --version
   - npm --version
-  - ps: set
+  - cmd: set
   - gradlew.bat compileJava compileTestJava --info --stacktrace --no-daemon
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,15 +4,14 @@ build:
   verbosity: detailed
 
 build_script:
-  - gradlew.bat compileJava compileTestJava --info --no-daemon
+  - gradlew.bat compileJava compileTestJava --info --stacktrace --no-daemon
 
 test_script:
-  - gradlew.bat dependencies --info --no-daemon
+  - gradlew.bat test --info --stacktrace --no-daemon
 
 branches:
   only:
-    - master
-    - development
+    - develop
 
 cache:
   - C:\Users\appveyor\.gradle

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,26 @@
+version: "{branch} {build}"
+
+build:
+  verbosity: detailed
+
+build_script:
+  - gradlew.bat compileJava compileTestJava --info --no-daemon
+
+test_script:
+  - gradlew.bat dependencies --info --no-daemon
+
+branches:
+  only:
+    - master
+    - development
+
+cache:
+  - C:\Users\appveyor\.gradle
+
+environment:
+  matrix:
+    - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+
+matrix:
+  fast_finish: true
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,9 +17,6 @@ cache:
   - C:\Users\appveyor\.gradle
 
 environment:
-  matrix:
-    - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
-
-matrix:
-  fast_finish: true
+  nodejs_version: "6"
+  JAVA_HOME: C:\Program Files\Java\jdk1.8.0
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,18 @@
 version: "{branch} {build}"
 
+environment:
+  nodejs_version: "10"
+  JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+
 build:
   verbosity: detailed
 
 build_script:
+  - node --version
+  - npm --version
   - gradlew.bat compileJava compileTestJava --info --stacktrace --no-daemon
 
 test_script:
@@ -15,8 +24,3 @@ branches:
 
 cache:
   - C:\Users\appveyor\.gradle
-
-environment:
-  nodejs_version: "6"
-  JAVA_HOME: C:\Program Files\Java\jdk1.8.0
-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ build:
 build_script:
   - node --version
   - npm --version
+  - ps: set
   - gradlew.bat compileJava compileTestJava --info --stacktrace --no-daemon
 
 test_script:

--- a/changelog/@unreleased/pr164.v2.yml
+++ b/changelog/@unreleased/pr164.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
 improvement:
-  description: Windows is now supported for cthe common conjure generators
+  description: Windows is now supported for the common conjure generators
   links:
     - https://github.com/palantir/gradle-conjure/pull/164

--- a/changelog/@unreleased/pr164.v2.yml
+++ b/changelog/@unreleased/pr164.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Windows is now supported for cthe common conjure generators
+  links:
+    - https://github.com/palantir/gradle-conjure/pull/164

--- a/gradle-conjure/build.gradle
+++ b/gradle-conjure/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     compile 'com.google.guava:guava'
     compile 'com.palantir.sls.versions:sls-versions'
     compile 'com.fasterxml.jackson.core:jackson-databind'
+    compile 'org.apache.commons:commons-lang3'
 
     annotationProcessor 'org.immutables:value'
     compileOnly 'org.immutables:value::annotations'

--- a/gradle-conjure/build.gradle
+++ b/gradle-conjure/build.gradle
@@ -25,7 +25,6 @@ dependencies {
     compile 'com.google.guava:guava'
     compile 'com.palantir.sls.versions:sls-versions'
     compile 'com.fasterxml.jackson.core:jackson-databind'
-    compile 'org.apache.commons:commons-lang3'
 
     annotationProcessor 'org.immutables:value'
     compileOnly 'org.immutables:value::annotations'

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.util.List;
 import java.util.function.Supplier;
+import org.apache.commons.lang3.SystemUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.InputDirectory;
@@ -30,6 +31,7 @@ import org.gradle.api.tasks.TaskAction;
 
 @CacheableTask
 public class CompileIrTask extends DefaultTask {
+    private static final String EXECUTABLE = "bin/conjure" + (SystemUtils.IS_OS_WINDOWS ? ".bat" : "");
 
     private File outputFile;
     private Supplier<File> inputDirectory;
@@ -69,7 +71,7 @@ public class CompileIrTask extends DefaultTask {
         getProject().exec(execSpec -> {
             ImmutableList.Builder<String> commandArgsBuilder = ImmutableList.builder();
             commandArgsBuilder.add(
-                    new File(executableDir.get(), "bin/conjure").getAbsolutePath(),
+                    new File(executableDir.get(), EXECUTABLE).getAbsolutePath(),
                     "compile",
                     inputDirectory.get().getAbsolutePath(),
                     outputFile.getAbsolutePath());

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.util.List;
 import java.util.function.Supplier;
-import org.apache.commons.lang3.SystemUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.InputDirectory;
@@ -31,7 +30,7 @@ import org.gradle.api.tasks.TaskAction;
 
 @CacheableTask
 public class CompileIrTask extends DefaultTask {
-    private static final String EXECUTABLE = "bin/conjure" + (SystemUtils.IS_OS_WINDOWS ? ".bat" : "");
+    private static final String EXECUTABLE = OsUtils.appendDotBatIfWindows("bin/conjure");
 
     private File outputFile;
     private Supplier<File> inputDirectory;

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureGeneratorTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureGeneratorTask.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+import org.apache.commons.lang3.SystemUtils;
 import org.gradle.api.Action;
 import org.gradle.api.Task;
 import org.gradle.api.tasks.CacheableTask;
@@ -66,7 +67,7 @@ public class ConjureGeneratorTask extends SourceTask {
     @InputFile
     @PathSensitive(PathSensitivity.NONE)
     public final File getExecutablePath() {
-        return executablePathSupplier.get();
+        return new File(executablePathSupplier.get().getAbsolutePath() + (SystemUtils.IS_OS_WINDOWS ? ".bat" : ""));
     }
 
     public final void setOptions(Supplier<GeneratorOptions> options) {

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureGeneratorTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureGeneratorTask.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
-import org.apache.commons.lang3.SystemUtils;
 import org.gradle.api.Action;
 import org.gradle.api.Task;
 import org.gradle.api.tasks.CacheableTask;
@@ -67,7 +66,7 @@ public class ConjureGeneratorTask extends SourceTask {
     @InputFile
     @PathSensitive(PathSensitivity.NONE)
     public final File getExecutablePath() {
-        return new File(executablePathSupplier.get().getAbsolutePath() + (SystemUtils.IS_OS_WINDOWS ? ".bat" : ""));
+        return OsUtils.appendDotBatIfWindows(executablePathSupplier.get());
     }
 
     public final void setOptions(Supplier<GeneratorOptions> options) {

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -418,9 +418,10 @@ public final class ConjurePlugin implements Plugin<Project> {
                             task.dependsOn(productDependencyTask);
                         });
 
+                String npmCommand = OsUtils.NPM_COMMAND_NAME;
                 Task installTypeScriptDependencies = project.getTasks().create("installTypeScriptDependencies",
                         Exec.class, task -> {
-                            task.commandLine("npm", "install", "--no-package-lock");
+                            task.commandLine(npmCommand, "install", "--no-package-lock");
                             task.workingDir(srcDirectory);
                             task.dependsOn(compileConjureTypeScript);
                             task.getInputs().file(new File(srcDirectory, "package.json"));
@@ -430,7 +431,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                     task.setDescription(
                             "Runs `npm tsc` to compile generated TypeScript files into JavaScript files.");
                     task.setGroup(TASK_GROUP);
-                    task.commandLine("npm", "run-script", "build");
+                    task.commandLine(npmCommand, "run-script", "build");
                     task.workingDir(srcDirectory);
                     task.dependsOn(installTypeScriptDependencies);
                 });
@@ -438,7 +439,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                     task.setDescription("Runs `npm publish` to publish a TypeScript package "
                             + "generated from your Conjure definitions.");
                     task.setGroup(TASK_GROUP);
-                    task.commandLine("npm", "publish");
+                    task.commandLine(npmCommand, "publish");
                     task.workingDir(srcDirectory);
                     task.dependsOn(compileConjureTypeScript);
                     task.dependsOn(compileTypeScript);

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/OsUtils.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/OsUtils.java
@@ -17,13 +17,13 @@
 package com.palantir.gradle.conjure;
 
 import java.io.File;
-import org.apache.commons.lang3.SystemUtils;
+import org.apache.tools.ant.taskdefs.condition.Os;
 
 final class OsUtils {
     private OsUtils() {}
 
     static String appendDotBatIfWindows(String executable) {
-        return executable + (SystemUtils.IS_OS_WINDOWS ? ".bat" : "");
+        return executable + (Os.isFamily(Os.FAMILY_WINDOWS) ? ".bat" : "");
     }
 
     static File appendDotBatIfWindows(File executable) {

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/OsUtils.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/OsUtils.java
@@ -20,13 +20,19 @@ import java.io.File;
 import org.apache.tools.ant.taskdefs.condition.Os;
 
 final class OsUtils {
+    public static final String NPM_COMMAND_NAME = appendIfWindows(".cmd", "npm");
+
     private OsUtils() {}
 
     static String appendDotBatIfWindows(String executable) {
-        return executable + (Os.isFamily(Os.FAMILY_WINDOWS) ? ".bat" : "");
+        return appendIfWindows(".bat", executable);
     }
 
     static File appendDotBatIfWindows(File executable) {
         return new File(appendDotBatIfWindows(executable.getPath()));
+    }
+
+    private static String appendIfWindows(String toAppend, String value) {
+        return value + (Os.isFamily(Os.FAMILY_WINDOWS) ? toAppend : "");
     }
 }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/OsUtils.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/OsUtils.java
@@ -27,6 +27,6 @@ final class OsUtils {
     }
 
     static File appendDotBatIfWindows(File executable) {
-        return new File(appendDotBatIfWindows(executable.getAbsolutePath()));
+        return new File(appendDotBatIfWindows(executable.getPath()));
     }
 }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/OsUtils.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/OsUtils.java
@@ -1,0 +1,32 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.conjure;
+
+import java.io.File;
+import org.apache.commons.lang3.SystemUtils;
+
+final class OsUtils {
+    private OsUtils() {}
+
+    static String appendDotBatIfWindows(String executable) {
+        return executable + (SystemUtils.IS_OS_WINDOWS ? ".bat" : "");
+    }
+
+    static File appendDotBatIfWindows(File executable) {
+        return new File(appendDotBatIfWindows(executable.getAbsolutePath()));
+    }
+}

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalPluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalPluginTest.groovy
@@ -20,7 +20,7 @@ import nebula.test.IntegrationSpec
 import nebula.test.functional.ExecutionResult
 
 class ConjureLocalPluginTest extends IntegrationSpec {
-    def standardBuildFile = '''
+    def standardBuildFile = """
         buildscript {
             repositories {
                 mavenCentral()
@@ -38,11 +38,11 @@ class ConjureLocalPluginTest extends IntegrationSpec {
             configurations.all {
                resolutionStrategy {
                    failOnVersionConflict()
-                   force 'com.palantir.conjure.java:conjure-java:3.10.0'
-                   force 'com.palantir.conjure.typescript:conjure-typescript:3.8.1'
-                   force 'com.palantir.conjure.python:conjure-python:3.9.0'
-                   force 'com.palantir.conjure:conjure:4.0.0'
-                   force 'com.palantir.conjure.postman:conjure-postman:0.1.0'
+                   force 'com.palantir.conjure.java:conjure-java:${TestVersions.CONJURE_JAVA}'
+                   force 'com.palantir.conjure.typescript:conjure-typescript:${TestVersions.CONJURE_TYPESCRIPT}'
+                   force 'com.palantir.conjure.python:conjure-python:${TestVersions.CONJURE_PYTHON}'
+                   force 'com.palantir.conjure:conjure:${TestVersions.CONJURE}'
+                   force 'com.palantir.conjure.postman:conjure-postman:${TestVersions.CONJURE_POSTMAN}'
                }
            }
         }
@@ -50,9 +50,9 @@ class ConjureLocalPluginTest extends IntegrationSpec {
         apply plugin: 'com.palantir.conjure-local'
         
         dependencies {
-            conjure 'com.palantir.conjure:conjure-api:4.1.1'
+            conjure 'com.palantir.conjure:conjure-api:${TestVersions.CONJURE}'
         }
-    '''.stripIndent()
+    """.stripIndent()
 
     def setup() {
         buildFile << standardBuildFile

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalPluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalPluginTest.groovy
@@ -39,7 +39,7 @@ class ConjureLocalPluginTest extends IntegrationSpec {
                resolutionStrategy {
                    failOnVersionConflict()
                    force 'com.palantir.conjure.java:conjure-java:3.10.0'
-                   force 'com.palantir.conjure.typescript:conjure-typescript:3.1.1'
+                   force 'com.palantir.conjure.typescript:conjure-typescript:3.8.0'
                    force 'com.palantir.conjure.python:conjure-python:3.9.0'
                    force 'com.palantir.conjure:conjure:4.0.0'
                    force 'com.palantir.conjure.postman:conjure-postman:0.1.0'

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalPluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalPluginTest.groovy
@@ -39,7 +39,7 @@ class ConjureLocalPluginTest extends IntegrationSpec {
                resolutionStrategy {
                    failOnVersionConflict()
                    force 'com.palantir.conjure.java:conjure-java:3.10.0'
-                   force 'com.palantir.conjure.typescript:conjure-typescript:3.8.0'
+                   force 'com.palantir.conjure.typescript:conjure-typescript:3.8.1'
                    force 'com.palantir.conjure.python:conjure-python:3.9.0'
                    force 'com.palantir.conjure:conjure:4.0.0'
                    force 'com.palantir.conjure.postman:conjure-postman:0.1.0'

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalPluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalPluginTest.groovy
@@ -131,6 +131,7 @@ class ConjureLocalPluginTest extends IntegrationSpec {
         ExecutionResult result = runTasksSuccessfully("generateConjure")
         result.wasExecuted(":generatePostman")
         fileExists('postman/postman/conjure-api/conjure-api.postman_collection.json')
-        file('postman/postman/conjure-api/conjure-api.postman_collection.json').text.contains('"version" : "4.1.1"')
+        file('postman/postman/conjure-api/conjure-api.postman_collection.json')
+                .text.contains(""""version" : "${TestVersions.CONJURE}\"""")
     }
 }

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -78,7 +78,7 @@ class ConjurePluginTest extends IntegrationSpec {
         createFile('versions.props') << '''
         com.fasterxml.jackson.*:* = 2.6.7
         com.google.guava:guava = 18.0
-        com.palantir.conjure.typescript:conjure-typescript = 3.8.0
+        com.palantir.conjure.typescript:conjure-typescript = 3.8.1
         com.palantir.conjure.java:* = 2.6.0
         com.palantir.conjure:conjure = 4.0.0
         com.squareup.retrofit2:retrofit = 2.1.0

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -75,16 +75,16 @@ class ConjurePluginTest extends IntegrationSpec {
         apply plugin: 'com.palantir.conjure'
         '''.stripIndent()
 
-        createFile('versions.props') << '''
+        createFile('versions.props') << """
         com.fasterxml.jackson.*:* = 2.6.7
         com.google.guava:guava = 18.0
-        com.palantir.conjure.typescript:conjure-typescript = 3.8.1
-        com.palantir.conjure.java:* = 2.6.0
-        com.palantir.conjure:conjure = 4.0.0
+        com.palantir.conjure.typescript:conjure-typescript = ${TestVersions.CONJURE_TYPESCRIPT}
+        com.palantir.conjure.java:* = ${TestVersions.CONJURE_JAVA}
+        com.palantir.conjure:conjure = ${TestVersions.CONJURE}
         com.squareup.retrofit2:retrofit = 2.1.0
         javax.annotation:javax.annotation-api = 1.3.2
         javax.ws.rs:javax.ws.rs-api = 2.0.1
-        '''.stripIndent()
+        """.stripIndent()
 
         createFile('api/src/main/conjure/api.yml') << '''
         types:
@@ -539,7 +539,7 @@ class ConjurePluginTest extends IntegrationSpec {
     def 'supports generic generators'() {
         addSubproject(':api:api-postman')
         file('versions.props') << """
-        com.palantir.conjure.postman:conjure-postman = 0.1.0
+        com.palantir.conjure.postman:conjure-postman = ${TestVersions.CONJURE_POSTMAN}
         """.stripIndent()
         file('api/build.gradle') << """
         dependencies {

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -402,7 +402,7 @@ class ConjurePluginTest extends IntegrationSpec {
 
         // typescript
         file('api/api-typescript/src/service/testServiceFoo2.ts').text.contains(
-                'import { IInternalImport } from "../internal/internalImport"')
+                'import { IInternalImport }')
 
         // ir
         fileExists("api/build/conjure-ir/api.conjure.json")

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -62,12 +62,6 @@ class ConjurePluginTest extends IntegrationSpec {
                 strategy OverrideTransitives
                 propertiesFile file: project.rootProject.file('versions.props')
             }
-
-            configurations.all {
-                resolutionStrategy {
-                    failOnVersionConflict()
-                }
-            }
         }
         '''.stripIndent()
 

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -78,7 +78,7 @@ class ConjurePluginTest extends IntegrationSpec {
         createFile('versions.props') << '''
         com.fasterxml.jackson.*:* = 2.6.7
         com.google.guava:guava = 18.0
-        com.palantir.conjure.typescript:conjure-typescript = 3.0.0
+        com.palantir.conjure.typescript:conjure-typescript = 3.8.0
         com.palantir.conjure.java:* = 2.6.0
         com.palantir.conjure:conjure = 4.0.0
         com.squareup.retrofit2:retrofit = 2.1.0

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePublishTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePublishTest.groovy
@@ -44,7 +44,7 @@ class ConjurePublishTest extends IntegrationSpec {
             configurations.all {
                resolutionStrategy {
                    failOnVersionConflict()
-                   force 'com.palantir.conjure:conjure:4.0.0'
+                   force 'com.palantir.conjure:conjure:${TestVersions.CONJURE}'
                }
             }
             

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePublishTypeScriptTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePublishTypeScriptTest.groovy
@@ -74,11 +74,11 @@ class ConjurePublishTypeScriptTest extends IntegrationSpec {
         apply plugin: 'com.palantir.conjure'
         '''.stripIndent()
 
-        createFile('versions.props') << '''
+        createFile('versions.props') << """
         com.google.guava:guava = 18.0
-        com.palantir.conjure.typescript:conjure-typescript = 3.8.1
-        com.palantir.conjure:conjure = 4.0.0
-        '''.stripIndent()
+        com.palantir.conjure.typescript:conjure-typescript = ${TestVersions.CONJURE_TYPESCRIPT}
+        com.palantir.conjure:conjure = ${TestVersions.CONJURE}
+        """.stripIndent()
 
         createFile('api/src/main/conjure/api.yml') << '''
         types:

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePublishTypeScriptTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePublishTypeScriptTest.groovy
@@ -76,7 +76,7 @@ class ConjurePublishTypeScriptTest extends IntegrationSpec {
 
         createFile('versions.props') << '''
         com.google.guava:guava = 18.0
-        com.palantir.conjure.typescript:conjure-typescript = 3.0.0
+        com.palantir.conjure.typescript:conjure-typescript = 3.8.0
         com.palantir.conjure:conjure = 4.0.0
         '''.stripIndent()
 

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePublishTypeScriptTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePublishTypeScriptTest.groovy
@@ -76,7 +76,7 @@ class ConjurePublishTypeScriptTest extends IntegrationSpec {
 
         createFile('versions.props') << '''
         com.google.guava:guava = 18.0
-        com.palantir.conjure.typescript:conjure-typescript = 3.8.0
+        com.palantir.conjure.typescript:conjure-typescript = 3.8.1
         com.palantir.conjure:conjure = 4.0.0
         '''.stripIndent()
 

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
@@ -60,7 +60,7 @@ class ConjureServiceDependencyTest extends IntegrationSpec {
         createFile('versions.props') << '''
         com.fasterxml.jackson.*:* = 2.6.7
         com.google.guava:guava = 18.0
-        com.palantir.conjure.typescript:conjure-typescript = 3.3.0
+        com.palantir.conjure.typescript:conjure-typescript = 3.8.0
         com.palantir.conjure.java:* = 2.3.0
         com.palantir.conjure:conjure = 4.0.0
         com.squareup.retrofit2:retrofit = 2.1.0

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
@@ -57,16 +57,16 @@ class ConjureServiceDependencyTest extends IntegrationSpec {
         }
         '''.stripIndent()
 
-        createFile('versions.props') << '''
+        createFile('versions.props') << """
         com.fasterxml.jackson.*:* = 2.6.7
         com.google.guava:guava = 18.0
-        com.palantir.conjure.typescript:conjure-typescript = 3.8.1
-        com.palantir.conjure.java:* = 2.3.0
-        com.palantir.conjure:conjure = 4.0.0
+        com.palantir.conjure.typescript:conjure-typescript = ${TestVersions.CONJURE_TYPESCRIPT}
+        com.palantir.conjure.java:* = ${TestVersions.CONJURE_JAVA}
+        com.palantir.conjure:conjure = ${TestVersions.CONJURE}
         com.squareup.retrofit2:retrofit = 2.1.0
         javax.annotation:javax.annotation-api = 1.3.2
         javax.ws.rs:javax.ws.rs-api = 2.0.1
-        '''.stripIndent()
+        """.stripIndent()
 
         createFile('api/build.gradle') << '''
         apply plugin: 'com.palantir.conjure'

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
@@ -60,7 +60,7 @@ class ConjureServiceDependencyTest extends IntegrationSpec {
         createFile('versions.props') << '''
         com.fasterxml.jackson.*:* = 2.6.7
         com.google.guava:guava = 18.0
-        com.palantir.conjure.typescript:conjure-typescript = 3.8.0
+        com.palantir.conjure.typescript:conjure-typescript = 3.8.1
         com.palantir.conjure.java:* = 2.3.0
         com.palantir.conjure:conjure = 4.0.0
         com.squareup.retrofit2:retrofit = 2.1.0

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/TestVersions.java
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/TestVersions.java
@@ -23,6 +23,6 @@ public final class TestVersions {
     public static final String CONJURE_JAVA = "3.11.1";
     public static final String CONJURE_PYTHON = "3.11.6";
     public static final String CONJURE_TYPESCRIPT = "3.8.1";
-    public static final String CONJURE_POSTMAN = "0.1.0";
+    public static final String CONJURE_POSTMAN = "0.1.2";
 
 }

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/TestVersions.java
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/TestVersions.java
@@ -1,0 +1,28 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.conjure;
+
+public final class TestVersions {
+    private TestVersions() { }
+
+    public static final String CONJURE = "4.6.2";
+    public static final String CONJURE_JAVA = "3.11.1";
+    public static final String CONJURE_PYTHON = "3.11.16";
+    public static final String CONJURE_TYPESCRIPT = "3.8.1";
+    public static final String CONJURE_POSTMAN = "0.1.0";
+
+}

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/TestVersions.java
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/TestVersions.java
@@ -21,7 +21,7 @@ public final class TestVersions {
 
     public static final String CONJURE = "4.6.2";
     public static final String CONJURE_JAVA = "3.11.1";
-    public static final String CONJURE_PYTHON = "3.11.16";
+    public static final String CONJURE_PYTHON = "3.11.6";
     public static final String CONJURE_TYPESCRIPT = "3.8.1";
     public static final String CONJURE_POSTMAN = "0.1.0";
 

--- a/versions.props
+++ b/versions.props
@@ -10,7 +10,6 @@ org.assertj:* = 3.12.2
 org.immutables:value = 2.7.5
 org.mockito:mockito-core = 2.27.0
 org.spockframework:* = 1.2-groovy-2.4
-org.apache.commons:commons-lang3 = 3.9
 
 
 # Resolve conflicts

--- a/versions.props
+++ b/versions.props
@@ -10,6 +10,8 @@ org.assertj:* = 3.12.2
 org.immutables:value = 2.7.5
 org.mockito:mockito-core = 2.27.0
 org.spockframework:* = 1.2-groovy-2.4
+org.apache.commons:commons-lang3 = 3.9
+
 
 # Resolve conflicts
 com.google.code.findbugs:jsr305 = 3.0.2


### PR DESCRIPTION
## Before this PR
Currently, conjure fails to generate on Windows as gradle-conjure always tries to execute a bash script to run IR compilation and generators. This is preventing me from using conjure in https://github.com/palantir/docker-compose-rule/pull/292 as we support develop from external developers who use windows.

## After this PR
==COMMIT_MSG==
Conjure IR generation and conjure generators will now be called by `${GENERATOR_NAME}.bat` on windows rather than simply `${GENERATOR_NAME}`. This allows windows support.
==COMMIT_MSG==

Conjure IR generation and java/python conjure generation at least already produce the required `.bat` files automatically. 