### PR TITLE
conjureGeneratorTask ensures only output files exist in output directory

### DIFF
--- a/changelog/@unreleased/pr-185.v2.yml
+++ b/changelog/@unreleased/pr-185.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Remove stale files from generator output directory
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/185

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureGeneratorTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureGeneratorTask.java
@@ -32,6 +32,7 @@ import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SourceTask;
+import org.gradle.util.GFileUtils;
 
 @CacheableTask
 public class ConjureGeneratorTask extends SourceTask {
@@ -96,6 +97,7 @@ public class ConjureGeneratorTask extends SourceTask {
                 ImmutableList.Builder<String> commandArgsBuilder = ImmutableList.builder();
                 File thisOutputDirectory = outputDirectoryFor(file);
                 getProject().mkdir(thisOutputDirectory);
+                GFileUtils.cleanDirectory(thisOutputDirectory);
                 commandArgsBuilder.add(
                         getExecutablePath().getAbsolutePath(),
                         "generate",

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureGeneratorTaskTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureGeneratorTaskTest.groovy
@@ -43,14 +43,14 @@ class ConjureGeneratorTaskTest extends IntegrationSpec {
         createFile('api/build.gradle') << """
         apply plugin: 'com.palantir.conjure'
         dependencies {
-            conjureCompiler 'com.palantir.conjure:conjure:${TestVersions.CONJURE_VERSION}'
-            conjureJava 'com.palantir.conjure.java:conjure-java:${TestVersions.CONJURE_JAVA_VERSION}'
+            conjureCompiler 'com.palantir.conjure:conjure:${TestVersions.CONJURE}'
+            conjureJava 'com.palantir.conjure.java:conjure-java:${TestVersions.CONJURE_JAVA}'
         }
 
         subprojects {
             pluginManager.withPlugin 'java', {
                 dependencies {
-                    compile 'com.palantir.conjure.java:conjure-lib:${TestVersions.CONJURE_JAVA_VERSION}'
+                    compile 'com.palantir.conjure.java:conjure-lib:${TestVersions.CONJURE_JAVA}'
                 }
             }
         }

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureGeneratorTaskTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureGeneratorTaskTest.groovy
@@ -1,0 +1,114 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.conjure
+
+import nebula.test.IntegrationSpec
+import nebula.test.functional.ExecutionResult
+
+class ConjureGeneratorTaskTest extends IntegrationSpec {
+    private static final String CONJURE_VERSION = "4.4.0"
+    private static final String CONJURE_JAVA_VERSION = "2.5.0"
+
+    def setup() {
+        createFile('settings.gradle') << '''
+        include 'api'
+        include 'api:api-objects'
+        '''.stripIndent()
+
+        createFile('build.gradle') << '''
+        allprojects {
+            version '0.1.0'
+            group 'com.palantir.conjure.test'
+
+            repositories {
+                mavenCentral()
+                maven {
+                    url 'https://dl.bintray.com/palantir/releases/'
+                }
+            }
+        }
+        '''.stripIndent()
+
+        createFile('api/build.gradle') << """
+        apply plugin: 'com.palantir.conjure'
+        dependencies {
+            conjureCompiler 'com.palantir.conjure:conjure:${CONJURE_VERSION}'
+            conjureJava 'com.palantir.conjure.java:conjure-java:${CONJURE_JAVA_VERSION}'
+        }
+
+        subprojects {
+            pluginManager.withPlugin 'java', {
+                dependencies {
+                    compile 'com.palantir.conjure.java:conjure-lib:${CONJURE_JAVA_VERSION}'
+                }
+            }
+        }
+        """.stripIndent()
+
+        createFile('api/src/main/conjure/api.yml') << '''
+        types:
+          definitions:
+            default-package: test.test.api
+            objects:
+              StringExample:
+                fields:
+                  string: string
+        '''.stripIndent()
+        file("gradle.properties") << "org.gradle.daemon=false"
+    }
+
+    def "generates all files"() {
+        when:
+        ExecutionResult result = runTasksSuccessfully(':api:compileConjure')
+
+        then:
+        result.wasExecuted(':api:compileConjure')
+        result.wasExecuted(':api:compileConjureObjects')
+        result.wasExecuted(':api:compileIr')
+
+        // java
+        fileExists('api/api-objects/src/generated/java/test/test/api/StringExample.java')
+    }
+
+    def "cleans up old files"() {
+        when:
+        ExecutionResult result = runTasksSuccessfully(':api:compileConjure')
+        file('api/src/main/conjure/api.yml').text = '''
+        types:
+          definitions:
+            default-package: test.test.api
+            objects:
+              NewStringExample:
+                fields:
+                  string: string
+        '''.stripIndent()
+        ExecutionResult result2 = runTasksSuccessfully(':api:compileConjure')
+
+        then:
+        result.wasExecuted(':api:compileConjure')
+        result.wasExecuted(':api:compileConjureObjects')
+        result.wasExecuted(':api:compileIr')
+
+        result2.wasExecuted(':api:compileConjure')
+        result2.wasExecuted(':api:compileConjureObjects')
+        result2.wasExecuted(':api:compileIr')
+
+        // java
+        !fileExists('api/api-objects/src/generated/java/test/test/api/StringExample.java')
+        fileExists('api/api-objects/src/generated/java/test/test/api/NewStringExample.java')
+    }
+}

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureGeneratorTaskTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureGeneratorTaskTest.groovy
@@ -20,9 +20,6 @@ import nebula.test.IntegrationSpec
 import nebula.test.functional.ExecutionResult
 
 class ConjureGeneratorTaskTest extends IntegrationSpec {
-    private static final String CONJURE_VERSION = "4.4.0"
-    private static final String CONJURE_JAVA_VERSION = "2.5.0"
-
     def setup() {
         createFile('settings.gradle') << '''
         include 'api'
@@ -46,14 +43,14 @@ class ConjureGeneratorTaskTest extends IntegrationSpec {
         createFile('api/build.gradle') << """
         apply plugin: 'com.palantir.conjure'
         dependencies {
-            conjureCompiler 'com.palantir.conjure:conjure:${CONJURE_VERSION}'
-            conjureJava 'com.palantir.conjure.java:conjure-java:${CONJURE_JAVA_VERSION}'
+            conjureCompiler 'com.palantir.conjure:conjure:${TestVersions.CONJURE_VERSION}'
+            conjureJava 'com.palantir.conjure.java:conjure-java:${TestVersions.CONJURE_JAVA_VERSION}'
         }
 
         subprojects {
             pluginManager.withPlugin 'java', {
                 dependencies {
-                    compile 'com.palantir.conjure.java:conjure-lib:${CONJURE_JAVA_VERSION}'
+                    compile 'com.palantir.conjure.java:conjure-lib:${TestVersions.CONJURE_JAVA_VERSION}'
                 }
             }
         }


### PR DESCRIPTION
## Before this PR
We would not clean up any old files/classes that had previously been generated. This resulted in those stale classes being counted as part of the output of the task and incorrectly stored in the build cache.

## After this PR
==COMMIT_MSG==
Remove stale files from generator output directory 
==COMMIT_MSG==

## Possible downsides?
N/A

