### PR TITLE
make gradle-conjure 6.0 compatible

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ subprojects {
     sourceCompatibility = 1.8
 
     tasks.withType(JavaCompile) {
-        options.compilerArgs += ['-Werror']
+        options.compilerArgs += ['-Werror', '-Xlint:deprecation']
         options.errorprone {
             check("PreferSafeLoggableExceptions", CheckSeverity.OFF)
         }

--- a/changelog/@unreleased/pr-195.v2.yml
+++ b/changelog/@unreleased/pr-195.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Gradle-conjure should now be compatible with Gradle 6.0
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/195

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureGeneratorTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureGeneratorTask.java
@@ -96,8 +96,8 @@ public class ConjureGeneratorTask extends SourceTask {
             getProject().exec(execSpec -> {
                 ImmutableList.Builder<String> commandArgsBuilder = ImmutableList.builder();
                 File thisOutputDirectory = outputDirectoryFor(file);
+                GFileUtils.deleteDirectory(thisOutputDirectory);
                 getProject().mkdir(thisOutputDirectory);
-                GFileUtils.cleanDirectory(thisOutputDirectory);
                 commandArgsBuilder.add(
                         getExecutablePath().getAbsolutePath(),
                         "generate",


### PR DESCRIPTION
In gradle 6.0 they made a small [change](https://github.com/gradle/gradle/commit/1c07bebdc54b57fb767fb283557c015a2fa85e41) to GFileUtils that caused gradle-conjure to break