### PR TITLE
Eliminate some warnings (because 'compile' is deprecated)

### DIFF
--- a/changelog/@unreleased/pr-202.v2.yml
+++ b/changelog/@unreleased/pr-202.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: gradle-conjure produces no longer sets up deprecated 'compile' dependencies,
+    instead preferring to declare 'api' dependencies (introduced with the java-library
+    plugin).
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/202

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CheckConjureJavaVersions.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CheckConjureJavaVersions.java
@@ -24,6 +24,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.util.VersionNumber;
 
@@ -45,9 +46,10 @@ public class CheckConjureJavaVersions extends DefaultTask {
                 .map(suffix -> getProject().findProject(getProject().getName() + suffix))
                 .filter(Objects::nonNull)
                 .forEach(subproj -> {
-                    VersionNumber conjureJavaLibVersion =
-                            findResolvedVersionOf(
-                                    subproj, "compile", ConjurePlugin.CONJURE_JAVA_LIB_DEP);
+                    VersionNumber conjureJavaLibVersion = findResolvedVersionOf(
+                            subproj,
+                            JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME,
+                            ConjurePlugin.CONJURE_JAVA_LIB_DEP);
                     boolean compatible = conjureJavaLibVersion.compareTo(conjureJavaVersion) >= 0;
                     Preconditions.checkState(
                             compatible,

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
@@ -33,7 +33,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.BasePlugin;
-import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.plugins.JavaLibraryPlugin;
 import org.gradle.util.GUtil;
 
 public final class ConjureLocalPlugin implements Plugin<Project> {
@@ -89,7 +89,7 @@ public final class ConjureLocalPlugin implements Plugin<Project> {
         ExtractExecutableTask extractJavaTask = ExtractExecutableTask.createExtractTask(
                 project, "extractConjureJava", conjureJavaConfig, conjureJavaDir, "conjure-java");
 
-        subproj.getPluginManager().apply(JavaPlugin.class);
+        subproj.getPluginManager().apply(JavaLibraryPlugin.class);
         ConjurePlugin.addGeneratedToMainSourceSet(subproj);
 
         Task gitignoreConjureJava = ConjurePlugin.createWriteGitignoreTask(

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
@@ -121,7 +121,7 @@ public final class ConjureLocalPlugin implements Plugin<Project> {
 
             Task cleanTask = project.getTasks().findByName(ConjurePlugin.TASK_CLEAN);
             cleanTask.dependsOn(project.getTasks().findByName("cleanGenerateJava"));
-            subproj.getDependencies().add("compile", subproj);
+            subproj.getDependencies().add("api", subproj);
         });
     }
 

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -219,7 +219,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                         });
                 Task cleanTask = project.getTasks().findByName(TASK_CLEAN);
                 cleanTask.dependsOn(project.getTasks().findByName("cleanCompileConjureObjects"));
-                subproj.getDependencies().add("compile", "com.palantir.conjure.java:conjure-lib");
+                subproj.getDependencies().add("api", "com.palantir.conjure.java:conjure-lib");
                 subproj.getDependencies().add("compileOnly", "javax.annotation:javax.annotation-api");
             });
         }
@@ -266,8 +266,8 @@ public final class ConjurePlugin implements Plugin<Project> {
                 ConjureJavaServiceDependencies.configureJavaServiceDependencies(subproj, productDependencyExt);
                 Task cleanTask = project.getTasks().findByName(TASK_CLEAN);
                 cleanTask.dependsOn(project.getTasks().findByName("cleanCompileConjureRetrofit"));
-                subproj.getDependencies().add("compile", project.findProject(objectsProjectName));
-                subproj.getDependencies().add("compile", "com.squareup.retrofit2:retrofit");
+                subproj.getDependencies().add("api", project.findProject(objectsProjectName));
+                subproj.getDependencies().add("api", "com.squareup.retrofit2:retrofit");
                 subproj.getDependencies().add("compileOnly", "javax.annotation:javax.annotation-api");
             });
         }
@@ -315,8 +315,8 @@ public final class ConjurePlugin implements Plugin<Project> {
                 ConjureJavaServiceDependencies.configureJavaServiceDependencies(subproj, productDependencyExt);
                 Task cleanTask = project.getTasks().findByName(TASK_CLEAN);
                 cleanTask.dependsOn(project.getTasks().findByName("cleanCompileConjureJersey"));
-                subproj.getDependencies().add("compile", project.findProject(objectsProjectName));
-                subproj.getDependencies().add("compile", "javax.ws.rs:javax.ws.rs-api");
+                subproj.getDependencies().add("api", project.findProject(objectsProjectName));
+                subproj.getDependencies().add("api", "javax.ws.rs:javax.ws.rs-api");
                 subproj.getDependencies().add("compileOnly", "javax.annotation:javax.annotation-api");
             });
         }
@@ -364,8 +364,8 @@ public final class ConjurePlugin implements Plugin<Project> {
                 ConjureJavaServiceDependencies.configureJavaServiceDependencies(subproj, productDependencyExt);
                 Task cleanTask = project.getTasks().findByName(TASK_CLEAN);
                 cleanTask.dependsOn(project.getTasks().findByName("cleanCompileConjureUndertow"));
-                subproj.getDependencies().add("compile", project.findProject(objectsProjectName));
-                subproj.getDependencies().add("compile", "com.palantir.conjure.java:conjure-undertow-lib");
+                subproj.getDependencies().add("api", project.findProject(objectsProjectName));
+                subproj.getDependencies().add("api", "com.palantir.conjure.java:conjure-undertow-lib");
             });
         }
     }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -40,7 +40,7 @@ import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.plugins.BasePlugin;
-import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.plugins.JavaLibraryPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.Copy;
 import org.gradle.api.tasks.Exec;
@@ -193,7 +193,7 @@ public final class ConjurePlugin implements Plugin<Project> {
         String objectsProjectName = project.getName() + JAVA_OBJECTS_SUFFIX;
         if (project.findProject(objectsProjectName) != null) {
             project.project(objectsProjectName, subproj -> {
-                subproj.getPluginManager().apply(JavaPlugin.class);
+                subproj.getPluginManager().apply(JavaLibraryPlugin.class);
                 addGeneratedToMainSourceSet(subproj);
                 project.getTasks().create(
                         "compileConjureObjects",
@@ -241,7 +241,7 @@ public final class ConjurePlugin implements Plugin<Project> {
             }
 
             project.project(retrofitProjectName, subproj -> {
-                subproj.getPluginManager().apply(JavaPlugin.class);
+                subproj.getPluginManager().apply(JavaLibraryPlugin.class);
                 addGeneratedToMainSourceSet(subproj);
                 project.getTasks().create("compileConjureRetrofit", ConjureGeneratorTask.class, task -> {
                     task.setDescription(
@@ -289,7 +289,7 @@ public final class ConjurePlugin implements Plugin<Project> {
             }
 
             project.project(jerseyProjectName, subproj -> {
-                subproj.getPluginManager().apply(JavaPlugin.class);
+                subproj.getPluginManager().apply(JavaLibraryPlugin.class);
                 addGeneratedToMainSourceSet(subproj);
                 project.getTasks().create("compileConjureJersey", ConjureGeneratorTask.class, task -> {
                     task.setDescription("Generates Jersey interfaces from your Conjure definitions "
@@ -338,7 +338,7 @@ public final class ConjurePlugin implements Plugin<Project> {
             }
 
             project.project(undertowProjectName, subproj -> {
-                subproj.getPluginManager().apply(JavaPlugin.class);
+                subproj.getPluginManager().apply(JavaLibraryPlugin.class);
                 addGeneratedToMainSourceSet(subproj);
                 project.getTasks().create("compileConjureUndertow", ConjureGeneratorTask.class, task -> {
                     task.setDescription(


### PR DESCRIPTION
## Before this PR

Users of gradle-conjure may see some lame deprecation warnings:

```
> Configure project :log-receiver-api
The compile configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 7.0. Please use the implementation or api configuration instead.
        at build_3eb5450vc53poxr4t2qpcbw9e.run(/Volumes/git/log-receiver/log-receiver-api/build.gradle:1)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```

## After this PR
==COMMIT_MSG==
gradle-conjure produces no longer sets up deprecated 'compile' dependencies, instead preferring to declare 'api' dependencies (introduced with the java-library plugin).
==COMMIT_MSG==

## Possible downsides?

If someone can't use java-library for their API projects then this PR would wreck them.

