### PR TITLE
Don't set source dirs with immutable set

### DIFF
--- a/changelog/@unreleased/pr-257.v2.yml
+++ b/changelog/@unreleased/pr-257.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: IDEA plugin source sets are no longer set as immutable, so modifications
+    to it by other plugins can occur.
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/257

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -625,10 +625,12 @@ public final class ConjurePlugin implements Plugin<Project> {
             // module.getSourceDirs / getGeneratedSourceDirs could be an immutable set, so defensively copy
             IdeaModule module = plugin.getModel().getModule();
             module.setSourceDirs(mutableSetWithExtraEntry(
-                    module.getSourceDirs(), project.file(JAVA_GENERATED_SOURCE_DIRNAME)));
+                    module.getSourceDirs(),
+                    project.file(JAVA_GENERATED_SOURCE_DIRNAME)));
 
             module.setGeneratedSourceDirs(mutableSetWithExtraEntry(
-                    module.getGeneratedSourceDirs(), project.file(JAVA_GENERATED_SOURCE_DIRNAME)));
+                    module.getGeneratedSourceDirs(),
+                    project.file(JAVA_GENERATED_SOURCE_DIRNAME)));
         });
         project.getPlugins().withType(EclipsePlugin.class, plugin -> {
             Task task = project.getTasks().findByName("eclipseClasspath");

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -25,7 +25,7 @@ import com.palantir.gradle.conjure.api.GeneratorOptions;
 import java.io.File;
 import java.nio.file.Paths;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -639,7 +639,7 @@ public final class ConjurePlugin implements Plugin<Project> {
     }
 
     private static <T> Set<T> mutableSetWithExtraEntry(Set<T> set, T extraItem) {
-        Set<T> newSet = new HashSet<>(set);
+        Set<T> newSet = new LinkedHashSet<>(set);
         set.add(extraItem);
         return newSet;
     }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -25,6 +25,7 @@ import com.palantir.gradle.conjure.api.GeneratorOptions;
 import java.io.File;
 import java.nio.file.Paths;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -623,16 +624,11 @@ public final class ConjurePlugin implements Plugin<Project> {
 
             // module.getSourceDirs / getGeneratedSourceDirs could be an immutable set, so defensively copy
             IdeaModule module = plugin.getModel().getModule();
-            module.setSourceDirs(ImmutableSet
-                    .<File>builder()
-                    .addAll(module.getSourceDirs())
-                    .add(project.file(JAVA_GENERATED_SOURCE_DIRNAME))
-                    .build());
-            module.setGeneratedSourceDirs(ImmutableSet
-                    .<File>builder()
-                    .addAll(module.getGeneratedSourceDirs())
-                    .add(project.file(JAVA_GENERATED_SOURCE_DIRNAME))
-                    .build());
+            module.setSourceDirs(mutableSetWithExtraEntry(
+                    module.getSourceDirs(), project.file(JAVA_GENERATED_SOURCE_DIRNAME)));
+
+            module.setGeneratedSourceDirs(mutableSetWithExtraEntry(
+                    module.getGeneratedSourceDirs(), project.file(JAVA_GENERATED_SOURCE_DIRNAME)));
         });
         project.getPlugins().withType(EclipsePlugin.class, plugin -> {
             Task task = project.getTasks().findByName("eclipseClasspath");
@@ -640,6 +636,12 @@ public final class ConjurePlugin implements Plugin<Project> {
                 task.dependsOn(compileConjure);
             }
         });
+    }
+
+    private static <T> Set<T> mutableSetWithExtraEntry(Set<T> set, T extraItem) {
+        Set<T> newSet = new HashSet<>(set);
+        set.add(extraItem);
+        return newSet;
     }
 
     static Task createWriteGitignoreTask(Project project, String taskName, File outputDir, String contents) {


### PR DESCRIPTION
## Before this PR
If anyone tries to modify the IDEA source sets after `gradle-conjure` has set them, like a certain internal gradle plugin, it will fail.

## After this PR
==COMMIT_MSG==
IDEA plugin source sets are no longer set as immutable, so modifications to it by other plugins can occur.
==COMMIT_MSG==