### PR TITLE
Actually don't set source sets as immutable

### DIFF
--- a/changelog/@unreleased/pr-258.v2.yml
+++ b/changelog/@unreleased/pr-258.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: The previous release had a bug, this release fixes that bug and correctly
+    configures source sets as not immutable.
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/258

--- a/changelog/@unreleased/pr-258.v2.yml
+++ b/changelog/@unreleased/pr-258.v2.yml
@@ -1,6 +1,5 @@
 type: fix
 fix:
-  description: The previous release had a bug, this release fixes that bug and correctly
-    configures source sets as not immutable.
+  description: Restores `./gradlew idea` functionality to pre-4.13.2 behaviour.
   links:
   - https://github.com/palantir/gradle-conjure/pull/258

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -642,7 +642,7 @@ public final class ConjurePlugin implements Plugin<Project> {
 
     private static <T> Set<T> mutableSetWithExtraEntry(Set<T> set, T extraItem) {
         Set<T> newSet = new LinkedHashSet<>(set);
-        set.add(extraItem);
+        newSet.add(extraItem);
         return newSet;
     }
 

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -25,7 +25,6 @@ import com.palantir.gradle.conjure.api.GeneratorOptions;
 import java.io.File;
 import java.nio.file.Paths;
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -47,7 +46,6 @@ import org.gradle.api.tasks.Copy;
 import org.gradle.api.tasks.Exec;
 import org.gradle.plugins.ide.eclipse.EclipsePlugin;
 import org.gradle.plugins.ide.idea.IdeaPlugin;
-import org.gradle.plugins.ide.idea.model.IdeaModule;
 import org.gradle.util.GFileUtils;
 import org.gradle.util.GUtil;
 
@@ -621,16 +619,6 @@ public final class ConjurePlugin implements Plugin<Project> {
             if (task != null) {
                 task.dependsOn(compileConjure);
             }
-
-            // module.getSourceDirs / getGeneratedSourceDirs could be an immutable set, so defensively copy
-            IdeaModule module = plugin.getModel().getModule();
-            module.setSourceDirs(mutableSetWithExtraEntry(
-                    module.getSourceDirs(),
-                    project.file(JAVA_GENERATED_SOURCE_DIRNAME)));
-
-            module.setGeneratedSourceDirs(mutableSetWithExtraEntry(
-                    module.getGeneratedSourceDirs(),
-                    project.file(JAVA_GENERATED_SOURCE_DIRNAME)));
         });
         project.getPlugins().withType(EclipsePlugin.class, plugin -> {
             Task task = project.getTasks().findByName("eclipseClasspath");
@@ -638,12 +626,6 @@ public final class ConjurePlugin implements Plugin<Project> {
                 task.dependsOn(compileConjure);
             }
         });
-    }
-
-    private static <T> Set<T> mutableSetWithExtraEntry(Set<T> set, T extraItem) {
-        Set<T> newSet = new LinkedHashSet<>(set);
-        newSet.add(extraItem);
-        return newSet;
     }
 
     static Task createWriteGitignoreTask(Project project, String taskName, File outputDir, String contents) {

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -573,6 +573,25 @@ class ConjurePluginTest extends IntegrationSpec {
         runTasksSuccessfully('compileConjure')
     }
 
+    def 'sets up idea source sets correctly'() {
+        when:
+        file('api/build.gradle') << '''
+            subprojects {
+                apply plugin: 'idea'
+            }
+        '''
+
+        runTasksSuccessfully('idea')
+
+        then:
+        def slurper = new XmlParser()
+        def module = slurper.parse(file('api/api-jersey/api-jersey.iml'))
+        def sourcesFolderUrls = module.component.content.sourceFolder.@url
+
+        sourcesFolderUrls.size() == 1
+        sourcesFolderUrls.iterator().next().contains('src/generated/java')
+    }
+
     @Unroll
     @IgnoreIf({ jvm.java11Compatible })
     def 'runs on version of gradle: #version'() {


### PR DESCRIPTION
## Before this PR
We tried to not set source sets as immtuables in #257, but made a stupid typo

## After this PR
==COMMIT_MSG==
The previous release had a bug, this release fixes that bug and correctly configures source sets as not immutable.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

