### PR TITLE
Set IDEA source dirs

### DIFF
--- a/changelog/@unreleased/pr-260.v2.yml
+++ b/changelog/@unreleased/pr-260.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Correctly set IDEA source directories.
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/260


### PR DESCRIPTION
## Before this PR
Since #258, the conjure plugin does not explicitly set the IDEA source directories. Instead it relies on the default value, which includes all source directories of all java sources. However this is a problem if a previously executed plugin/script has set (overridden) the IDEA source directories because the conjure generated directory will no longer be included

## After this PR
The conjure plugin once again sets the IDEA source directories.

This PR reverts #258 and updates the test to ensure correct behavior when source directories have been previously set.

