### PR TITLE
Set the path sensitivity of ConjureGeneratorTask sources

### DIFF
--- a/changelog/@unreleased/pr-310.v2.yml
+++ b/changelog/@unreleased/pr-310.v2.yml
@@ -1,19 +1,5 @@
 type: improvement
 improvement:
-  description: |-
-    Set the path sensitivity of ConjureGeneratorTask sources
-
-    This allows the Gradle build cache to function across different
-    machines (or different repo locations on the same file system)
-    when running ConjureGeneratorTasks.
-
-    ## Before this PR
-    Remote Gradle build caching works for compileIr tasks, but not e.g. compileConjureObjects tasks.
-
-    ## After this PR
-    Remote Gradle build caching works for ConjureGeneratorTasks.
-
-    ## Possible downsides?
-    If a custom generator uses the non-relative part of the source path (i.e. the repo location) for something, caching could become inaccurate. This seems unlikely to be something someone would do intentionally. A possible protection against this would be passing a relative path to `outputDirectoryFor` rather than an absolute path. That would protect against `outputDirectoryFor` overrides, though not `compileFiles` overrides.
+  description: Enable Gradle remote build caches for ConjureGeneratorTasks.
   links:
   - https://github.com/palantir/gradle-conjure/pull/310

--- a/changelog/@unreleased/pr-310.v2.yml
+++ b/changelog/@unreleased/pr-310.v2.yml
@@ -1,0 +1,19 @@
+type: improvement
+improvement:
+  description: |-
+    Set the path sensitivity of ConjureGeneratorTask sources
+
+    This allows the Gradle build cache to function across different
+    machines (or different repo locations on the same file system)
+    when running ConjureGeneratorTasks.
+
+    ## Before this PR
+    Remote Gradle build caching works for compileIr tasks, but not e.g. compileConjureObjects tasks.
+
+    ## After this PR
+    Remote Gradle build caching works for ConjureGeneratorTasks.
+
+    ## Possible downsides?
+    If a custom generator uses the non-relative part of the source path (i.e. the repo location) for something, caching could become inaccurate. This seems unlikely to be something someone would do intentionally. A possible protection against this would be passing a relative path to `outputDirectoryFor` rather than an absolute path. That would protect against `outputDirectoryFor` overrides, though not `compileFiles` overrides.
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/310

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureGeneratorTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureGeneratorTask.java
@@ -55,7 +55,7 @@ public class ConjureGeneratorTask extends SourceTask {
     // Set the path sensitivity of the sources, which would otherwise default to ABSOLUTE
     @Override
     @PathSensitive(PathSensitivity.RELATIVE)
-    public FileTree getSource() {
+    public final FileTree getSource() {
         return super.getSource();
     }
 

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureGeneratorTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureGeneratorTask.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 import org.gradle.api.Action;
 import org.gradle.api.Task;
+import org.gradle.api.file.FileTree;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
@@ -49,6 +50,13 @@ public class ConjureGeneratorTask extends SourceTask {
                 compileFiles();
             }
         });
+    }
+
+    // Set the path sensitivity of the sources, which would otherwise default to ABSOLUTE
+    @Override
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public FileTree getSource() {
+        return super.getSource();
     }
 
     public final void setOutputDirectory(File outputDirectory) {


### PR DESCRIPTION
This allows the Gradle build cache to function across different
machines (or different repo locations on the same file system)
when running ConjureGeneratorTasks.

## Before this PR
Remote Gradle build caching works for compileIr tasks, but not e.g. compileConjureObjects tasks.

## After this PR
Remote Gradle build caching works for ConjureGeneratorTasks.

## Possible downsides?
If a custom generator uses the non-relative part of the source path (i.e. the repo location) for something, caching could become inaccurate. This seems unlikely to be something someone would do intentionally. A possible protection against this would be passing a relative path to `outputDirectoryFor` rather than an absolute path. That would protect against `outputDirectoryFor` overrides, though not `compileFiles` overrides.