### PR TITLE
Add listenablefuture dependency to retrofit project

### DIFF
--- a/changelog/@unreleased/pr-321.v2.yml
+++ b/changelog/@unreleased/pr-321.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Retrofit API projects now include a dependency on Guava.
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/321

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -289,6 +289,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                 Task cleanTask = project.getTasks().findByName(TASK_CLEAN);
                 cleanTask.dependsOn(project.getTasks().findByName("cleanCompileConjureRetrofit"));
                 subproj.getDependencies().add("api", project.findProject(objectsProjectName));
+                subproj.getDependencies().add("api", "com.google.guava:guava");
                 subproj.getDependencies().add("api", "com.squareup.retrofit2:retrofit");
                 subproj.getDependencies().add("compileOnly", ANNOTATION_API);
             });

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -141,11 +141,14 @@ class ConjurePluginTest extends IntegrationSpec {
         ExecutionResult result = runTasksSuccessfully('check')
 
         then:
+        result.wasExecuted(':api:api-objects:compileJava')
+        result.wasExecuted(':api:compileConjureObjects')
         result.wasExecuted(':api:api-jersey:compileJava')
         result.wasExecuted(':api:compileConjureJersey')
+        result.wasExecuted(':api:api-retrofit:compileJava')
+        result.wasExecuted(':api:compileConjureRetrofit')
         result.wasExecuted(':api:api-undertow:compileJava')
         result.wasExecuted(':api:compileConjureUndertow')
-        result.wasExecuted(':api:compileConjureObjects')
 
         fileExists('api/api-objects/src/generated/java/test/test/api/StringExample.java')
         fileExists('api/api-objects/.gitignore')
@@ -158,14 +161,24 @@ class ConjurePluginTest extends IntegrationSpec {
 
         then:
         result.wasExecuted(':api:extractConjureJava')
+        result.wasExecuted(':api:api-objects:compileJava')
+        result.wasExecuted(':api:compileConjureObjects')
         result.wasExecuted(':api:api-jersey:compileJava')
         result.wasExecuted(':api:compileConjureJersey')
-        result.wasExecuted(':api:compileConjureObjects')
+        result.wasExecuted(':api:api-retrofit:compileJava')
+        result.wasExecuted(':api:compileConjureRetrofit')
+        result.wasExecuted(':api:api-undertow:compileJava')
+        result.wasExecuted(':api:compileConjureUndertow')
 
         result2.wasUpToDate(':api:extractConjureJava')
-        result2.wasUpToDate(":api:api-jersey:compileJava")
-        result2.wasUpToDate(":api:compileConjureJersey")
-        result2.wasUpToDate(":api:compileConjureObjects")
+        result2.wasUpToDate(':api:api-objects:compileJava')
+        result2.wasUpToDate(':api:compileConjureObjects')
+        result2.wasUpToDate(':api:api-jersey:compileJava')
+        result2.wasUpToDate(':api:compileConjureJersey')
+        result2.wasUpToDate(':api:api-retrofit:compileJava')
+        result2.wasUpToDate(':api:compileConjureRetrofit')
+        result2.wasUpToDate(':api:api-undertow:compileJava')
+        result2.wasUpToDate(':api:compileConjureUndertow')
     }
 
     def 'compileIr can get results from the build cache'() {


### PR DESCRIPTION
## Before this PR
The retrofit API project does not include a dependency on Guava when using `ListenableFuture`. This will become more problematic once `ListenableFuture` is the default (see palantir/conjure-java#641).

## After this PR
The retrofit API project includes a dependency on Guava.

