### PR TITLE
Add validation-api dependency to jersey projects

### DIFF
--- a/changelog/@unreleased/pr-322.v2.yml
+++ b/changelog/@unreleased/pr-322.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Jersey API projects now include a dependency on `jakarta.validation:jakarta.validation-api`.
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/322

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -341,6 +341,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                 subproj.getDependencies().add("api", project.findProject(objectsProjectName));
                 subproj.getDependencies().add("api", "javax.ws.rs:javax.ws.rs-api");
                 subproj.getDependencies().add("compileOnly", ANNOTATION_API);
+                subproj.getDependencies().add("implementation", "jakarta.validation:jakarta.validation-api");
             });
         }
     }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -90,6 +90,8 @@ public final class ConjurePlugin implements Plugin<Project> {
     static final String JAVA_GENERATED_SOURCE_DIRNAME = "src/generated/java";
     static final String JAVA_GITIGNORE_CONTENTS = "/src/generated/java/\n";
 
+    private static final String JAVA_OPTIONS_REQUIRE_NON_NULL = "requireNotNullAuthAndBodyParams";
+
     static final String CONJURE_JAVA_LIB_DEP = "com.palantir.conjure.java:conjure-lib";
 
     /** Configuration where custom generators should be added as dependencies. */
@@ -341,7 +343,10 @@ public final class ConjurePlugin implements Plugin<Project> {
                 subproj.getDependencies().add("api", project.findProject(objectsProjectName));
                 subproj.getDependencies().add("api", "javax.ws.rs:javax.ws.rs-api");
                 subproj.getDependencies().add("compileOnly", ANNOTATION_API);
-                subproj.getDependencies().add("implementation", "jakarta.validation:jakarta.validation-api");
+
+                if (optionsSupplier.get().has(JAVA_OPTIONS_REQUIRE_NON_NULL)) {
+                    subproj.getDependencies().add("implementation", "jakarta.validation:jakarta.validation-api");
+                }
             });
         }
     }

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -78,6 +78,7 @@ class ConjurePluginTest extends IntegrationSpec {
         com.palantir.conjure.java:* = ${TestVersions.CONJURE_JAVA}
         com.palantir.conjure:conjure = ${TestVersions.CONJURE}
         com.squareup.retrofit2:retrofit = 2.1.0
+        jakarta.validation:jakarta.validation-api = 2.0.2
         javax.ws.rs:javax.ws.rs-api = 2.0.1
         """.stripIndent()
 

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
@@ -64,6 +64,7 @@ class ConjureServiceDependencyTest extends IntegrationSpec {
         com.palantir.conjure.java:* = ${TestVersions.CONJURE_JAVA}
         com.palantir.conjure:conjure = ${TestVersions.CONJURE}
         com.squareup.retrofit2:retrofit = 2.1.0
+        jakarta.validation:jakarta.validation-api = 2.0.2
         javax.ws.rs:javax.ws.rs-api = 2.0.1
         """.stripIndent()
 


### PR DESCRIPTION
Fixes #271

## Before this PR
Users that want to use `requireNotNullAuthAndBodyParams` have to manually add the `jakarta.validation:jakarta.validation-api` to their Jersey projects.

## After this PR
The `jakarta.validation:jakarta.validation-api` dependency is applied by default to all Jersey projects.

## Possible downsides?
- This dependency is applied even if you aren't using `requireNotNullAuthAndBodyParams`. However the dependency is pretty small and we are planning to make `requireNotNullAuthAndBodyParams` enabled by default (https://github.com/palantir/conjure-java/issues/51).