### PR TITLE
Replace javax.ws.rs-api with jakarta.ws.rs-api

### DIFF
--- a/changelog/@unreleased/pr-325.v2.yml
+++ b/changelog/@unreleased/pr-325.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Jersey API projects now include a dependency on `jakarta.ws.rs:jakarta.ws.rs-api`
+    instead of `javax.ws.rs:javax.ws.rs-api`.
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/325

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -240,7 +240,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                 Task cleanTask = project.getTasks().findByName(TASK_CLEAN);
                 cleanTask.dependsOn(project.getTasks().findByName("cleanCompileConjureObjects"));
                 subproj.getDependencies().add("api", "com.palantir.conjure.java:conjure-lib");
-                subproj.getDependencies().add("compileOnly", "javax.annotation:javax.annotation-api");
+                subproj.getDependencies().add("compileOnly", "jakarta.annotation:jakarta.annotation-api");
             });
         }
     }
@@ -288,7 +288,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                 cleanTask.dependsOn(project.getTasks().findByName("cleanCompileConjureRetrofit"));
                 subproj.getDependencies().add("api", project.findProject(objectsProjectName));
                 subproj.getDependencies().add("api", "com.squareup.retrofit2:retrofit");
-                subproj.getDependencies().add("compileOnly", "javax.annotation:javax.annotation-api");
+                subproj.getDependencies().add("compileOnly", "jakarta.annotation:jakarta.annotation-api");
             });
         }
     }
@@ -336,8 +336,8 @@ public final class ConjurePlugin implements Plugin<Project> {
                 Task cleanTask = project.getTasks().findByName(TASK_CLEAN);
                 cleanTask.dependsOn(project.getTasks().findByName("cleanCompileConjureJersey"));
                 subproj.getDependencies().add("api", project.findProject(objectsProjectName));
-                subproj.getDependencies().add("api", "javax.ws.rs:javax.ws.rs-api");
-                subproj.getDependencies().add("compileOnly", "javax.annotation:javax.annotation-api");
+                subproj.getDependencies().add("api", "jakarta.ws.rs:jakarta.ws.rs-api");
+                subproj.getDependencies().add("compileOnly", "jakarta.annotation:jakarta.annotation-api");
             });
         }
     }

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -78,8 +78,8 @@ class ConjurePluginTest extends IntegrationSpec {
         com.palantir.conjure.java:* = ${TestVersions.CONJURE_JAVA}
         com.palantir.conjure:conjure = ${TestVersions.CONJURE}
         com.squareup.retrofit2:retrofit = 2.1.0
-        javax.annotation:javax.annotation-api = 1.3.2
-        javax.ws.rs:javax.ws.rs-api = 2.0.1
+        jakarta.annotation:jakarta.annotation-api = 1.3.5
+        jakarta.ws.rs:jakarta.ws.rs-api = 2.1.6
         """.stripIndent()
 
         createFile('api/src/main/conjure/api.yml') << '''

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
@@ -64,8 +64,8 @@ class ConjureServiceDependencyTest extends IntegrationSpec {
         com.palantir.conjure.java:* = ${TestVersions.CONJURE_JAVA}
         com.palantir.conjure:conjure = ${TestVersions.CONJURE}
         com.squareup.retrofit2:retrofit = 2.1.0
-        javax.annotation:javax.annotation-api = 1.3.2
-        javax.ws.rs:javax.ws.rs-api = 2.0.1
+        jakarta.annotation:jakarta.annotation-api = 1.3.5
+        jakarta.ws.rs:jakarta.ws.rs-api = 2.1.6
         """.stripIndent()
 
         createFile('api/build.gradle') << '''


### PR DESCRIPTION
This was changed in conjure-java-runtime in https://github.com/palantir/conjure-java-runtime/pull/1372. Generated conjure projects should use the same dependency.