### PR TITLE
Specify a version for annotation-api

### DIFF
--- a/changelog/@unreleased/pr-331.v2.yml
+++ b/changelog/@unreleased/pr-331.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: gradle-conjure no longer requires users to provide a version number
+    for `javax.annotation:javax.annotation-api`, instead it will just set up a dependency
+    on latest (1.3.2).  This can still be substituted later with the new jakarta version.
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/331

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -95,6 +95,8 @@ public final class ConjurePlugin implements Plugin<Project> {
     /** Configuration where custom generators should be added as dependencies. */
     static final String CONJURE_GENERATORS_CONFIGURATION_NAME = "conjureGenerators";
     static final String CONJURE_GENERATOR_DEP_PREFIX = "conjure-";
+    /** Make the old Java8 @Generated annotation available even when compiling with Java9+. */
+    private static final String ANNOTATION_API = "javax.annotation:javax.annotation-api:1.3.2";
 
     @Override
     public void apply(Project project) {
@@ -240,7 +242,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                 Task cleanTask = project.getTasks().findByName(TASK_CLEAN);
                 cleanTask.dependsOn(project.getTasks().findByName("cleanCompileConjureObjects"));
                 subproj.getDependencies().add("api", "com.palantir.conjure.java:conjure-lib");
-                subproj.getDependencies().add("compileOnly", "javax.annotation:javax.annotation-api");
+                subproj.getDependencies().add("compileOnly", ANNOTATION_API);
             });
         }
     }
@@ -288,7 +290,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                 cleanTask.dependsOn(project.getTasks().findByName("cleanCompileConjureRetrofit"));
                 subproj.getDependencies().add("api", project.findProject(objectsProjectName));
                 subproj.getDependencies().add("api", "com.squareup.retrofit2:retrofit");
-                subproj.getDependencies().add("compileOnly", "javax.annotation:javax.annotation-api");
+                subproj.getDependencies().add("compileOnly", ANNOTATION_API);
             });
         }
     }
@@ -337,7 +339,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                 cleanTask.dependsOn(project.getTasks().findByName("cleanCompileConjureJersey"));
                 subproj.getDependencies().add("api", project.findProject(objectsProjectName));
                 subproj.getDependencies().add("api", "javax.ws.rs:javax.ws.rs-api");
-                subproj.getDependencies().add("compileOnly", "javax.annotation:javax.annotation-api");
+                subproj.getDependencies().add("compileOnly", ANNOTATION_API);
             });
         }
     }

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -78,7 +78,6 @@ class ConjurePluginTest extends IntegrationSpec {
         com.palantir.conjure.java:* = ${TestVersions.CONJURE_JAVA}
         com.palantir.conjure:conjure = ${TestVersions.CONJURE}
         com.squareup.retrofit2:retrofit = 2.1.0
-        javax.annotation:javax.annotation-api = 1.3.2
         javax.ws.rs:javax.ws.rs-api = 2.0.1
         """.stripIndent()
 

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
@@ -64,7 +64,6 @@ class ConjureServiceDependencyTest extends IntegrationSpec {
         com.palantir.conjure.java:* = ${TestVersions.CONJURE_JAVA}
         com.palantir.conjure:conjure = ${TestVersions.CONJURE}
         com.squareup.retrofit2:retrofit = 2.1.0
-        javax.annotation:javax.annotation-api = 1.3.2
         javax.ws.rs:javax.ws.rs-api = 2.0.1
         """.stripIndent()
 


### PR DESCRIPTION
## Before this PR

We're starting to move from javax -> jakarta as a consequence of taking a [jersey upgrade in c-j-r](https://github.com/palantir/conjure-java-runtime/pull/1372) (and transitively in WC).  Unfortunately, this means that the wc-bom has suddently stopped providing a version recommendation of `javax.annotation:javax.annotation-api = 1.3.2`.  This means people's WC upgrades are getting stuck with errors like the following.

```
Could not determine the dependencies of task ':rescue:compileJava'.
> Could not resolve all task dependencies for configuration ':rescue-internal-objects:compileClasspath'.
   > Could not find javax.validation:validation-api:.
     Required by:
         project :rescue-internal-objects
```

Note that this happens even with my gradle-jakarta-renames plugin applied, as the resolution comes later.

## After this PR
==COMMIT_MSG==
gradle-conjure no longer requires users to provide a version number for `javax.annotation:javax.annotation-api`, instead it will just set up a dependency on latest (1.3.2).  This can still be substituted later with the new jakarta version.
==COMMIT_MSG==

I considered switching to jakata straight away here (https://mvnrepository.com/artifact/jakarta.annotation/jakarta.annotation-api) but figured it's best to do minimal changes to unblock things first, as I really want to get baseline-class-uniqueness running everywhere before we do more of this.

## Possible downsides?
- I honestly can't remember why we didn't do this originally... it seems to just be net better?