### PR TITLE
add conjure-java-local plugin

### DIFF
--- a/changelog/@unreleased/pr-363.v2.yml
+++ b/changelog/@unreleased/pr-363.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Add new `conjure-java-local` plugin which allows for first class Java
+    local codegen
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/363

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -37,7 +37,7 @@ import org.gradle.api.tasks.TaskProvider;
 public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
     private static final String CONJURE_CONFIGURATION = "conjure";
     private static final Pattern DEFINITION_NAME =
-            Pattern.compile("(.*)-([0-9]+\\.[0-9]+\\.[0-9]+(?:-rc[0-9]+)?(?:-[0-9]+-g[a-f0-9]+)?)(.conjure)?.json");
+            Pattern.compile("(.*)-([0-9]+\\.[0-9]+\\.[0-9]+(?:-rc[0-9]+)?(?:-[0-9]+-g[a-f0-9]+)?)(\\.conjure)?\\.json");
 
     static final String CONJURE_JAVA = "conjureJava";
     static final String CONJURE_JAVA_BINARY = "com.palantir.conjure.java:conjure-java";
@@ -49,7 +49,7 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
         ConjureExtension extension =
                 project.getExtensions().create(ConjureExtension.EXTENSION_NAME, ConjureExtension.class);
 
-        Configuration conjureIrConfiguration = project.getConfigurations().maybeCreate(CONJURE_CONFIGURATION);
+        Configuration conjureIrConfiguration = project.getConfigurations().create(CONJURE_CONFIGURATION);
         TaskProvider<Copy> extractConjureIr = project.getTasks().register("extractConjureIr", Copy.class, task -> {
             task.rename(DEFINITION_NAME, "$1.conjure.json");
             task.from(conjureIrConfiguration);

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -75,7 +75,7 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
         // Validating that each subproject has a corresponding definition and vice versa.
         // We do this in afterEvaluate to ensure the configuration is populated.
         project.afterEvaluate(p -> {
-            Set<String> apis = conjureIrConfiguration.getAllDependencies().stream()
+            Set<String> apis = conjureIrConfiguration.getIncoming().getDependencies().stream()
                     .map(Dependency::getName)
                     .collect(ImmutableSet.toImmutableSet());
 

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -19,8 +19,9 @@ package com.palantir.gradle.conjure;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.palantir.gradle.conjure.api.ConjureExtension;
-import com.palantir.gradle.conjure.api.GeneratorOptions;
 import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 import org.gradle.api.Plugin;
@@ -112,9 +113,11 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
                     task.getExecutablePath().set(project.getLayout().file(project.provider(() ->
                             OsUtils.appendDotBatIfWindows(extractJavaTask.getExecutable()))));
                     task.getOptions().set(project.provider(() -> {
-                        GeneratorOptions options = new GeneratorOptions(extension.getJava());
-                        options.setProperty("packagePrefix", project.getGroup().toString());
-                        return options.getProperties();
+                        Map<String, Object> properties =
+                                new HashMap<>(extension.getJava().getProperties());
+                        properties.putIfAbsent(
+                                "packagePrefix", project.getGroup().toString());
+                        return properties;
                     }));
                     task.getOutputDirectory().set(project.file(ConjurePlugin.JAVA_GENERATED_SOURCE_DIRNAME));
                     task.dependsOn(extractJavaTask, extractConjureIr, generateGitIgnore);

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -1,0 +1,125 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.conjure;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.palantir.gradle.conjure.api.ConjureExtension;
+import com.palantir.gradle.conjure.api.GeneratorOptions;
+import java.io.File;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.plugins.BasePlugin;
+import org.gradle.api.plugins.JavaLibraryPlugin;
+import org.gradle.api.tasks.Copy;
+import org.gradle.api.tasks.TaskProvider;
+
+public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
+    private static final String CONJURE_CONFIGURATION = "conjure";
+    private static final Pattern DEFINITION_NAME =
+            Pattern.compile("(.*)-([0-9]+\\.[0-9]+\\.[0-9]+(?:-rc[0-9]+)?(?:-[0-9]+-g[a-f0-9]+)?)(.conjure)?.json");
+
+    static final String CONJURE_JAVA = "conjureJava";
+    static final String CONJURE_JAVA_BINARY = "com.palantir.conjure.java:conjure-java";
+
+    @Override
+    public void apply(Project project) {
+        project.getPlugins().apply(BasePlugin.class);
+
+        ConjureExtension extension =
+                project.getExtensions().create(ConjureExtension.EXTENSION_NAME, ConjureExtension.class);
+
+        Configuration conjureIrConfiguration = project.getConfigurations().maybeCreate(CONJURE_CONFIGURATION);
+        TaskProvider<Copy> extractConjureIr = project.getTasks().register("extractConjureIr", Copy.class, task -> {
+            task.rename(DEFINITION_NAME, "$1.conjure.json");
+            task.from(conjureIrConfiguration);
+            task.into(project.getLayout().getBuildDirectory().dir("conjure-ir"));
+        });
+
+        Configuration conjureJavaConfig = project.getConfigurations().maybeCreate(CONJURE_JAVA);
+        File conjureJavaDir = new File(project.getBuildDir(), CONJURE_JAVA);
+        project.getDependencies().add(CONJURE_JAVA, CONJURE_JAVA_BINARY);
+        ExtractExecutableTask extractJavaTask = ExtractExecutableTask.createExtractTask(
+                project, "extractConjureJava", conjureJavaConfig, conjureJavaDir, "conjure-java");
+
+        setupSubprojects(project, extension, extractJavaTask, extractConjureIr, conjureIrConfiguration);
+    }
+
+    private static void setupSubprojects(
+            Project project,
+            ConjureExtension extension,
+            ExtractExecutableTask extractJavaTask,
+            TaskProvider<Copy> extractConjureIr,
+            Configuration conjureIrConfiguration) {
+
+        // Validating that each subproject has a corresponding definition and vice versa.
+        // We do this in afterEvaluate to ensure the configuration is populated.
+        project.afterEvaluate(p -> {
+            Set<String> apis = conjureIrConfiguration.getAllDependencies().stream()
+                    .map(Dependency::getName)
+                    .collect(ImmutableSet.toImmutableSet());
+
+            Sets.SetView<String> missingProjects =
+                    Sets.difference(apis, project.getChildProjects().keySet());
+            if (!missingProjects.isEmpty()) {
+                throw new RuntimeException(String.format(
+                        "Discovered dependencies %s without corresponding subprojects.", missingProjects));
+            }
+            Sets.SetView<String> missingApis =
+                    Sets.difference(project.getChildProjects().keySet(), apis);
+            if (!missingApis.isEmpty()) {
+                throw new RuntimeException(
+                        String.format("Discovered subprojects %s without corresponding dependencies.", missingApis));
+            }
+        });
+
+        project.getChildProjects().forEach((name, subproject) -> {
+            subproject.getPluginManager().apply(JavaLibraryPlugin.class);
+            createGenerateTask(subproject, extension, extractJavaTask, extractConjureIr);
+        });
+    }
+
+    private static void createGenerateTask(
+            Project project,
+            ConjureExtension extension,
+            ExtractExecutableTask extractJavaTask,
+            TaskProvider<Copy> extractConjureIr) {
+        Task generateGitIgnore = ConjurePlugin.createWriteGitignoreTask(
+                project, "gitignoreConjure", project.getProjectDir(), ConjurePlugin.JAVA_GITIGNORE_CONTENTS);
+        TaskProvider<ConjureJavaLocalGeneratorTask> generateJava = project.getTasks()
+                .register("generateConjure", ConjureJavaLocalGeneratorTask.class, task -> {
+                    task.setSource(extractConjureIr.map(
+                            irTask -> new File(irTask.getDestinationDir(), project.getName() + ".conjure.json")));
+                    task.getExecutablePath().set(project.getLayout().file(project.provider(() ->
+                            OsUtils.appendDotBatIfWindows(extractJavaTask.getExecutable()))));
+                    task.getOptions().set(project.provider(() -> {
+                        GeneratorOptions options = new GeneratorOptions(extension.getJava());
+                        options.setProperty("packagePrefix", project.getGroup().toString());
+                        return options.getProperties();
+                    }));
+                    task.getOutputDirectory().set(project.file(ConjurePlugin.JAVA_GENERATED_SOURCE_DIRNAME));
+                    task.dependsOn(extractJavaTask, extractConjureIr, generateGitIgnore);
+                });
+        project.getTasks().named("compileJava").configure(compileJava -> compileJava.dependsOn(generateJava));
+        ConjurePlugin.applyDependencyForIdeTasks(project, generateJava.get());
+    }
+}

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -56,7 +56,7 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
             task.into(project.getLayout().getBuildDirectory().dir("conjure-ir"));
         });
 
-        Configuration conjureJavaConfig = project.getConfigurations().maybeCreate(CONJURE_JAVA);
+        Configuration conjureJavaConfig = project.getConfigurations().create(CONJURE_JAVA);
         File conjureJavaDir = new File(project.getBuildDir(), CONJURE_JAVA);
         project.getDependencies().add(CONJURE_JAVA, CONJURE_JAVA_BINARY);
         ExtractExecutableTask extractJavaTask = ExtractExecutableTask.createExtractTask(

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalGeneratorTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalGeneratorTask.java
@@ -1,0 +1,111 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.conjure;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileTree;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.SourceTask;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.util.GFileUtils;
+
+@CacheableTask
+public class ConjureJavaLocalGeneratorTask extends SourceTask {
+    private static final ImmutableSet<String> GENERATOR_FLAGS =
+            ImmutableSet.of("objects", "jersey", "undertow", "dialogue");
+
+    private final RegularFileProperty executablePath = getProject().getObjects().fileProperty();
+    private final DirectoryProperty outputDirectory = getProject().getObjects().directoryProperty();
+    private final MapProperty<String, Object> options =
+            getProject().getObjects().mapProperty(String.class, Object.class);
+
+    // Set the path sensitivity of the sources, which would otherwise default to ABSOLUTE
+    @Override
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public final FileTree getSource() {
+        return super.getSource();
+    }
+
+    @OutputDirectory
+    public final DirectoryProperty getOutputDirectory() {
+        return outputDirectory;
+    }
+
+    @InputFile
+    @PathSensitive(PathSensitivity.NONE)
+    public final RegularFileProperty getExecutablePath() {
+        return executablePath;
+    }
+
+    @Input
+    public final MapProperty<String, Object> getOptions() {
+        return this.options;
+    }
+
+    @TaskAction
+    public final void generate() {
+        Preconditions.checkArgument(getSource().getFiles().size() == 1, "Exactly one input file must be specified");
+        Map<String, Object> generatorOptions = getOptions().get();
+        Preconditions.checkArgument(
+                GENERATOR_FLAGS.stream().anyMatch(generatorOptions::containsKey),
+                "Generator options must contain at least one of %s",
+                GENERATOR_FLAGS);
+        File definitionFile = getSource().getFiles().iterator().next();
+
+        File outputDir = outputDirectory.getAsFile().get();
+        GFileUtils.deleteDirectory(outputDir);
+        getProject().mkdir(outputDir);
+
+        GENERATOR_FLAGS.forEach(generatorFlag -> {
+            if (!generatorOptions.containsKey(generatorFlag)) {
+                return;
+            }
+
+            // Need to ensure we don't invoke the generator with two flags from GENERATOR_FLAGS
+            Map<String, Object> filteredOptions = Maps.filterKeys(
+                    generatorOptions, key -> !GENERATOR_FLAGS.contains(key) || generatorFlag.equals(key));
+            getProject().exec(execSpec -> {
+                ImmutableList.Builder<String> commandArgsBuilder = ImmutableList.builder();
+                commandArgsBuilder.add(
+                        getExecutablePath().getAsFile().get().getAbsolutePath(),
+                        "generate",
+                        definitionFile.getAbsolutePath(),
+                        outputDir.getAbsolutePath());
+
+                List<String> additionalArgs = RenderGeneratorOptions.toArgs(filteredOptions, Collections.emptyMap());
+                getLogger().info("Running generator with args: {}", additionalArgs);
+                commandArgsBuilder.addAll(additionalArgs);
+                execSpec.commandLine(commandArgsBuilder.build().toArray());
+            });
+        });
+    }
+}

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/RenderGeneratorOptions.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/RenderGeneratorOptions.java
@@ -34,11 +34,13 @@ public final class RenderGeneratorOptions {
 
     /**
      * Renders a {@link GeneratorOptions} to command-line arguments.
-     *
      * @param requiredOptions a map of required options to their default values
      */
     public static List<String> toArgs(GeneratorOptions options, Map<String, Supplier<Object>> requiredOptions) {
-        Map<String, Object> properties = options.getProperties();
+        return toArgs(options.getProperties(), requiredOptions);
+    }
+
+    public static List<String> toArgs(Map<String, Object> properties, Map<String, Supplier<Object>> requiredOptions) {
         ImmutableMap.Builder<String, Object> resolvedProperties =
                 ImmutableMap.<String, Object>builder().putAll(properties);
         requiredOptions.forEach((field, defaultSupplierOpt) -> {

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/RenderGeneratorOptions.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/RenderGeneratorOptions.java
@@ -19,6 +19,7 @@ package com.palantir.gradle.conjure;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.gradle.conjure.api.GeneratorOptions;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -57,6 +58,7 @@ public final class RenderGeneratorOptions {
         });
 
         return resolvedProperties.build().entrySet().stream()
+                .sorted(Comparator.comparing(Map.Entry::getKey))
                 .map(entry -> {
                     Object value = entry.getValue();
                     if (value == Boolean.TRUE) {

--- a/gradle-conjure/src/main/resources/META-INF/gradle-plugins/com.palantir.conjure-java-local.properties
+++ b/gradle-conjure/src/main/resources/META-INF/gradle-plugins/com.palantir.conjure-java-local.properties
@@ -1,0 +1,1 @@
+implementation-class=com.palantir.gradle.conjure.ConjureJavaLocalCodegenPlugin

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPluginIntegrationSpec.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPluginIntegrationSpec.groovy
@@ -28,7 +28,7 @@ class ConjureJavaLocalCodegenPluginIntegrationSpec extends IntegrationSpec {
         }
         
         allprojects {
-            group = 'test.abc.group'
+            group = 'test.group'
             version = '1.0.0'
         
             repositories {
@@ -73,9 +73,9 @@ class ConjureJavaLocalCodegenPluginIntegrationSpec extends IntegrationSpec {
         result.wasExecuted("extractConjureIr")
         result.wasExecuted("conjure-api:generateConjure")
         fileExists("build/conjure-ir/conjure-api.conjure.json")
-        fileExists('conjure-api/src/generated/java/com/palantir/conjure/spec/ConjureDefinition.java')
-        result.standardOutput.contains "Running generator with args: [--jersey, --packagePrefix=test.abc.group]"
-        result.standardOutput.contains "Running generator with args: [--objects, --packagePrefix=test.abc.group]"
+        fileExists('conjure-api/src/generated/java/test/group/com/palantir/conjure/spec/ConjureDefinition.java')
+        result.standardOutput.contains "Running generator with args: [--jersey, --packagePrefix=test.group]"
+        result.standardOutput.contains "Running generator with args: [--objects, --packagePrefix=test.group]"
     }
 
     def 'check code compiles'() {
@@ -89,7 +89,7 @@ class ConjureJavaLocalCodegenPluginIntegrationSpec extends IntegrationSpec {
         result.wasExecuted(':conjure-api:compileJava')
         result.wasExecuted(':conjure-api:generateConjure')
 
-        fileExists('conjure-api/src/generated/java/com/palantir/conjure/spec/ConjureDefinition.java')
+        fileExists('conjure-api/src/generated/java/test/group/com/palantir/conjure/spec/ConjureDefinition.java')
     }
 
     def 'sets up idea source sets correctly'() {

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPluginIntegrationSpec.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPluginIntegrationSpec.groovy
@@ -1,0 +1,148 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.conjure
+
+import nebula.test.IntegrationSpec
+import nebula.test.functional.ExecutionResult
+
+class ConjureJavaLocalCodegenPluginIntegrationSpec extends IntegrationSpec {
+    def standardBuildFile = """
+        buildscript {
+            repositories {
+                mavenCentral()
+            }
+        }
+        
+        allprojects {
+            group = 'test.abc.group'
+            version = '1.0.0'
+        
+            repositories {
+                mavenCentral()
+                maven { url 'https://dl.bintray.com/palantir/releases/' }
+            }
+
+            configurations.all {
+               resolutionStrategy {
+                   failOnVersionConflict()
+                   force 'com.palantir.conjure.java:conjure-java:${TestVersions.CONJURE_JAVA}'
+                   force 'com.palantir.conjure:conjure:${TestVersions.CONJURE}'
+               }
+           }
+        }
+        
+        apply plugin: 'com.palantir.conjure-java-local'
+        dependencies {
+            conjure 'com.palantir.conjure:conjure-api:${TestVersions.CONJURE}'
+        }
+    """.stripIndent()
+
+    def setup() {
+        buildFile << standardBuildFile;
+    }
+
+    def "generates projects"() {
+        buildFile << """
+        conjure {
+            java {
+                addFlag "jersey"
+                addFlag "objects"
+            }
+        }
+        """.stripIndent()
+        addSubproject("conjure-api")
+
+        when:
+        def result = runTasksSuccessfully(":conjure-api:generateConjure")
+
+        then:
+        result.wasExecuted("extractConjureIr")
+        result.wasExecuted("conjure-api:generateConjure")
+        fileExists("build/conjure-ir/conjure-api.conjure.json")
+        fileExists('conjure-api/src/generated/java/com/palantir/conjure/spec/ConjureDefinition.java')
+        result.standardOutput.contains "Running generator with args: [--jersey, --packagePrefix=test.abc.group]"
+        result.standardOutput.contains "Running generator with args: [--objects, --packagePrefix=test.abc.group]"
+    }
+
+    def 'check code compiles'() {
+        addSubproject("conjure-api")
+        buildFile << "conjure { java { addFlag 'objects' } }"
+
+        when:
+        ExecutionResult result = runTasksSuccessfully('check')
+
+        then:
+        result.wasExecuted(':conjure-api:compileJava')
+        result.wasExecuted(':conjure-api:generateConjure')
+
+        fileExists('conjure-api/src/generated/java/com/palantir/conjure/spec/ConjureDefinition.java')
+    }
+
+    def 'sets up idea source sets correctly'() {
+        buildFile << """
+        conjure { java { addFlag 'objects' } }
+        subprojects {
+            apply plugin: 'idea'
+        }
+        """.stripIndent()
+        addSubproject("conjure-api")
+
+        when:
+        runTasksSuccessfully('idea')
+
+        then:
+        def slurper = new XmlParser()
+        def module = slurper.parse(file('conjure-api/conjure-api.iml'))
+        def sourcesFolderUrls = module.component.content.sourceFolder.@url
+
+        sourcesFolderUrls.size() == 1
+        sourcesFolderUrls.contains('file://$MODULE_DIR$/src/generated/java')
+    }
+
+    def "fails if missing corresponding subproject"() {
+        when:
+        buildFile << """
+        task dummy {}
+        """.stripIndent()
+        def result = runTasksWithFailure("dummy")
+
+        then:
+        result.standardError.contains "Discovered dependencies [conjure-api] without corresponding subprojects."
+    }
+
+    def "fails if missing dependency"() {
+        addSubproject("conjure-api")
+        addSubproject("missing-api")
+        when:
+        buildFile << """
+        task dummy {}
+        """.stripIndent()
+        def result = runTasksWithFailure("dummy")
+
+        then:
+        result.standardError.contains "Discovered subprojects [missing-api] without corresponding dependencies."
+    }
+
+    def "fails to generate without required flags"() {
+        addSubproject("conjure-api")
+        when:
+        def result = runTasksWithFailure(":conjure-api:generateConjure")
+
+        then:
+        result.standardError.contains "Generator options must contain at least one of"
+    }
+}

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPluginIntegrationSpec.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPluginIntegrationSpec.groovy
@@ -78,6 +78,26 @@ class ConjureJavaLocalCodegenPluginIntegrationSpec extends IntegrationSpec {
         result.standardOutput.contains "Running generator with args: [--objects, --packagePrefix=test.group]"
     }
 
+    def "respects user provided packagePrefix"() {
+        buildFile << """
+        conjure {
+            java {
+                addFlag "objects"
+                packagePrefix = "user.group"
+            }
+        }
+        """.stripIndent()
+        addSubproject("conjure-api")
+
+        when:
+        def result = runTasksSuccessfully(":conjure-api:generateConjure")
+
+        then:
+        result.wasExecuted("extractConjureIr")
+        fileExists('conjure-api/src/generated/java/user/group/com/palantir/conjure/spec/ConjureDefinition.java')
+        result.standardOutput.contains "Running generator with args: [--objects, --packagePrefix=user.group]"
+    }
+
     def 'check code compiles'() {
         addSubproject("conjure-api")
         buildFile << "conjure { java { addFlag 'objects' } }"

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -474,22 +474,6 @@ class ConjurePluginTest extends IntegrationSpec {
         !result.wasExecuted(':api:compileConjureJersey')
     }
 
-    def 'featureFlag RetrofitCompletableFutures can be enabled'() {
-        file('api/build.gradle') << '''
-        conjure {
-            java {
-                retrofitCompletableFutures = true
-            }
-        }
-        '''.stripIndent()
-
-        when:
-        ExecutionResult result = runTasksSuccessfully(':api:compileConjureRetrofit')
-
-        then:
-        fileExists('api/api-retrofit/src/generated/java/test/test/api/TestServiceFooRetrofit.java')
-        file('api/api-retrofit/src/generated/java/test/test/api/TestServiceFooRetrofit.java').text.contains('CompletableFuture<StringExample>')
-    }
 
     def 'featureFlag UndertowServicePrefix can be enabled'() {
         file('api/build.gradle') << '''
@@ -541,7 +525,8 @@ class ConjurePluginTest extends IntegrationSpec {
         ExecutionResult result = runTasks(':api:compileConjureTypeScript')
 
         then:
-        result.standardOutput.contains("--nodeCompatibleModules --unknownOps=Unknown");
+        result.standardOutput.contains("--nodeCompatibleModules")
+        result.standardOutput.contains("--unknownOps=Unknown")
     }
 
     def 'works with afterEvaluate'() {

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/TestVersions.java
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/TestVersions.java
@@ -20,7 +20,7 @@ public final class TestVersions {
     private TestVersions() {}
 
     public static final String CONJURE = "4.6.2";
-    public static final String CONJURE_JAVA = "3.11.1";
+    public static final String CONJURE_JAVA = "5.3.0";
     public static final String CONJURE_PYTHON = "3.11.6";
     public static final String CONJURE_TYPESCRIPT = "3.8.1";
     public static final String CONJURE_POSTMAN = "0.1.2";

--- a/gradle-conjure/src/test/java/com/palantir/gradle/conjure/RenderGeneratorOptionsTest.java
+++ b/gradle-conjure/src/test/java/com/palantir/gradle/conjure/RenderGeneratorOptionsTest.java
@@ -31,7 +31,7 @@ public class RenderGeneratorOptionsTest {
         generatorOptions.setProperty("foo", true);
         generatorOptions.setProperty("bar", false);
         assertThat(RenderGeneratorOptions.toArgs(generatorOptions, ImmutableMap.of()))
-                .containsExactly("--foo", "--bar=false");
+                .containsExactly("--bar=false", "--foo");
     }
 
     @Test
@@ -68,6 +68,6 @@ public class RenderGeneratorOptionsTest {
     public void testDefault() {
         generatorOptions.setProperty("foo", "bar");
         assertThat(RenderGeneratorOptions.toArgs(generatorOptions, ImmutableMap.of("baz", () -> "yep")))
-                .containsExactly("--foo=bar", "--baz=yep");
+                .containsExactly("--baz=yep", "--foo=bar");
     }
 }


### PR DESCRIPTION
## Before this PR
We had some support for java local codegen, but it definitely wasn't supported in a first class way.

## After this PR
==COMMIT_MSG==
Add new `conjure-java-local` plugin which allows for first class Java local codegen
==COMMIT_MSG==

This plugin will generate bindings for each individual API in child project. Below an example of what the expected project structure would look like:
directories:
```
└── remote-api/
    ├── bar-api/
    ├── build.gradle
    └── foo-api/
```

build.gradle
```gradle
apply plugin: 'conjure-java-local'

conjure {
  java {
    addFlag 'objects'
    addFlag 'jersey'
    addFlag 'strictObjects'
  }
}

dependencies {
   conjure 'com.palantir.foo:foo-api:1.0.0'
   conjure 'com.palantir.bar:bar-api:2.0.0'
}
```


## Possible downsides?
The plugin is incredibly unopinionated, only requiring that a package prefix is provided (defaulting to the current project group), so users are able to locally codegen anything that they would like.

