### PR TITLE
Fix: Use jakarta-api instead javax-api

### DIFF
--- a/changelog/@unreleased/pr-371.v2.yml
+++ b/changelog/@unreleased/pr-371.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Stop using legacy javax.ws.rs:javax.ws.rs-api when compiling jersey
+    projects
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/371

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -284,7 +284,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                 Task cleanTask = project.getTasks().findByName(TASK_CLEAN);
                 cleanTask.dependsOn(project.getTasks().findByName("cleanCompileConjureJersey"));
                 subproj.getDependencies().add("api", project.findProject(objectsProjectName));
-                subproj.getDependencies().add("api", "javax.ws.rs:javax.ws.rs-api");
+                subproj.getDependencies().add("api", "jakarta.ws.rs:jakarta.ws.rs-api");
                 subproj.getDependencies().add("compileOnly", ANNOTATION_API);
             });
         }

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -78,7 +78,7 @@ class ConjurePluginTest extends IntegrationSpec {
         com.palantir.conjure.java:* = ${TestVersions.CONJURE_JAVA}
         com.palantir.conjure:conjure = ${TestVersions.CONJURE}
         com.squareup.retrofit2:retrofit = 2.1.0
-        javax.ws.rs:javax.ws.rs-api = 2.0.1
+        jakarta.ws.rs:jakarta.ws.rs-api = 2.1.6
         """.stripIndent()
 
         createFile('api/src/main/conjure/api.yml') << '''

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
@@ -64,7 +64,7 @@ class ConjureServiceDependencyTest extends IntegrationSpec {
         com.palantir.conjure.java:* = ${TestVersions.CONJURE_JAVA}
         com.palantir.conjure:conjure = ${TestVersions.CONJURE}
         com.squareup.retrofit2:retrofit = 2.1.0
-        javax.ws.rs:javax.ws.rs-api = 2.0.1
+        jakarta.ws.rs:jakarta.ws.rs-api = 2.1.6
         """.stripIndent()
 
         createFile('api/build.gradle') << '''


### PR DESCRIPTION
## Before this PR
We had been using old javax.ws.rs:javax.ws.rs-api which can lead to build failures via checkUnusedDependencies from gradle-baseline

## After this PR
==COMMIT_MSG==
Stop using legacy javax.ws.rs:javax.ws.rs-api when compiling jersey projects
==COMMIT_MSG==

## Possible downsides?
N/A, this api should be backwards compatible