### PR TITLE
Ignore unused conjure-lib from java subprojects

### DIFF
--- a/changelog/@unreleased/pr-373.v2.yml
+++ b/changelog/@unreleased/pr-373.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: If `com.palantir.baseline-exact-dependencies` is found, configure its
+    task to ignore `conjure-lib` because it is always added to subprojects by this
+    plugin.
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/373

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -202,7 +202,6 @@ public final class ConjurePlugin implements Plugin<Project> {
                 Task cleanTask = project.getTasks().findByName(TASK_CLEAN);
                 cleanTask.dependsOn(project.getTasks().findByName("cleanCompileConjureObjects"));
                 subproj.getDependencies().add("api", "com.palantir.conjure.java:conjure-lib");
-                subproj.getDependencies().add("compileOnly", ANNOTATION_API);
             });
         }
     }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -351,6 +351,8 @@ public final class ConjurePlugin implements Plugin<Project> {
                 Method ignoreMethod = task.getClass().getMethod("ignore", String.class, String.class);
                 List<String> conjureJavaLibComponents = Splitter.on(':').splitToList(CONJURE_JAVA_LIB_DEP);
                 ignoreMethod.invoke(task, conjureJavaLibComponents.get(0), conjureJavaLibComponents.get(1));
+                // also ignore guava since retrofit adds it...
+                ignoreMethod.invoke(task, "com.google.guava", "guava");
             } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
                 log.warn("Failed to ignore conjure-lib from baseline's checkUnusedDependencies", e);
             }

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -635,6 +635,7 @@ class ConjurePluginTest extends IntegrationSpec {
 
     @RestoreSystemProperties
     def 'works with checkUnusedDependencies'() {
+        System.setProperty("ignoreMutableProjectStateWarnings", "true")
         // Due to errors like 'The configuration :api:api-objects:compileClasspath was resolved without accessing the project in a safe manner.'
         System.setProperty("ignoreDeprecations", "true")
         buildFile << """

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -635,9 +635,9 @@ class ConjurePluginTest extends IntegrationSpec {
 
     @RestoreSystemProperties
     def 'works with checkUnusedDependencies'() {
-        System.setProperty("ignoreMutableProjectStateWarnings", "true")
         // Due to errors like 'The configuration :api:api-objects:compileClasspath was resolved without accessing the project in a safe manner.'
         System.setProperty("ignoreDeprecations", "true")
+        System.setProperty("ignoreMutableProjectStateWarnings", "true")
         buildFile << """
             allprojects { apply plugin: 'com.palantir.baseline-exact-dependencies' }
         """.stripIndent()


### PR DESCRIPTION
## Before this PR

Users of baseline's [checkUnusedDependencies](https://github.com/palantir/gradle-baseline/#compalantirbaseline-exact-dependencies) get an error if they enable it on conjure java subprojects:

```
> Found 2 dependencies unused during compilation, please delete them from 'foo/foo-objects/build.gradle' or choose one of the suggested fixes:
        com.palantir.conjure.java:conjure-lib
                Did you mean:
                        implementation com.fasterxml.jackson.core:jackson-annotations
                        implementation com.fasterxml.jackson.core:jackson-databind
                        implementation com.palantir.ri:resource-identifier
                        implementation com.palantir.safe-logging:preconditions
                        implementation com.palantir.safe-logging:safe-logging
        javax.ws.rs:javax.ws.rs-api
```

## After this PR
==COMMIT_MSG==
If `com.palantir.baseline-exact-dependencies` is found, configure its task to ignore `conjure-lib` because it is always added to subprojects by this plugin.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

