### PR TITLE
plumb product dependencies to conjure core

### DIFF
--- a/changelog/@unreleased/pr-381.v2.yml
+++ b/changelog/@unreleased/pr-381.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add product dependency information into produced Conjure IR
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/381

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
@@ -98,7 +98,8 @@ public class CompileIrTask extends DefaultTask {
     private String getSerializedExtensions() {
         try {
             return GenerateConjureServiceDependenciesTask.jsonMapper.writeValueAsString(ImmutableMap.of(
-                    "product-dependencies", getProductDependencies().get()));
+                    "sls-recommended-product-dependencies",
+                    getProductDependencies().get()));
         } catch (IOException e) {
             throw new RuntimeException("Failed to serialize conjure extensions", e);
         }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
@@ -98,8 +98,7 @@ public class CompileIrTask extends DefaultTask {
     private String getSerializedExtensions() {
         try {
             return GenerateConjureServiceDependenciesTask.jsonMapper.writeValueAsString(ImmutableMap.of(
-                    "sls-recommended-product-dependencies",
-                    getProductDependencies().get()));
+                    "recommended-product-dependencies", getProductDependencies().get()));
         } catch (IOException e) {
             throw new RuntimeException("Failed to serialize conjure extensions", e);
         }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -117,7 +117,7 @@ public final class ConjurePlugin implements Plugin<Project> {
         applyDependencyForIdeTasks(project, compileConjure);
 
         Copy copyConjureSourcesTask = getConjureSources(project);
-        Task compileIrTask = createCompileIrTask(project, copyConjureSourcesTask);
+        Task compileIrTask = createCompileIrTask(project, conjureProductDependenciesExtension, copyConjureSourcesTask);
         GenerateConjureServiceDependenciesTask productDependencyTask = project.getTasks()
                 .create("generateConjureServiceDependencies", GenerateConjureServiceDependenciesTask.class, task -> {
                     task.setConjureServiceDependencies(conjureProductDependenciesExtension::getProductDependencies);
@@ -649,7 +649,8 @@ public final class ConjurePlugin implements Plugin<Project> {
         return writeGitignoreTask;
     }
 
-    private static Task createCompileIrTask(Project project, Copy copyConjureSourcesTask) {
+    private static Task createCompileIrTask(
+            Project project, ConjureProductDependenciesExtension pdepsExtension, Copy copyConjureSourcesTask) {
         Configuration conjureCompilerConfig = project.getConfigurations().maybeCreate(CONJURE_COMPILER);
         File conjureCompilerDir = new File(project.getBuildDir(), CONJURE_COMPILER);
         project.getDependencies().add(CONJURE_COMPILER, CONJURE_COMPILER_BINARY);
@@ -665,6 +666,7 @@ public final class ConjurePlugin implements Plugin<Project> {
             compileIr.setInputDirectory(copyConjureSourcesTask::getDestinationDir);
             compileIr.setExecutableDir(extractCompilerTask::getOutputDirectory);
             compileIr.setOutputFile(irPath);
+            compileIr.getProductDependencies().set(project.provider(pdepsExtension::getProductDependencies));
             compileIr.dependsOn(copyConjureSourcesTask);
             compileIr.dependsOn(extractCompilerTask);
         });

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
@@ -144,7 +144,7 @@ class ConjureServiceDependencyTest extends IntegrationSpec {
 
         then:
         result.standardOutput.find('Running compiler with args: \\[.*, --extensions, '
-                + '\\{"product-dependencies":\\[\\{'
+                + '\\{"sls-recommended-product-dependencies":\\[\\{'
                 + '"product-group":"com.palantir.conjure",'
                 + '"product-name":"conjure",'
                 + '"minimum-version":"1.2.0",'

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
@@ -143,7 +143,7 @@ class ConjureServiceDependencyTest extends IntegrationSpec {
         def result = runTasksSuccessfully(':api:compileConjure')
 
         then:
-        result.standardOutput.find('Running compiler with args: \\[.*, --extensions, '
+        result.standardOutput.find('Running with args: \\[.*, --extensions, '
                 + '\\{"recommended-product-dependencies":\\[\\{'
                 + '"product-group":"com.palantir.conjure",'
                 + '"product-name":"conjure",'

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
@@ -144,7 +144,7 @@ class ConjureServiceDependencyTest extends IntegrationSpec {
 
         then:
         result.standardOutput.find('Running compiler with args: \\[.*, --extensions, '
-                + '\\{"sls-recommended-product-dependencies":\\[\\{'
+                + '\\{"recommended-product-dependencies":\\[\\{'
                 + '"product-group":"com.palantir.conjure",'
                 + '"product-name":"conjure",'
                 + '"minimum-version":"1.2.0",'

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
@@ -127,6 +127,31 @@ class ConjureServiceDependencyTest extends IntegrationSpec {
         file('api/build/service-dependencies.json').text.contains('"recommended-version":"1.2.0"')
     }
 
+    def "correctly passes product dependencies to conjure"() {
+        file('api/build.gradle') << '''
+        serviceDependencies {
+            serviceDependency {
+                productGroup = "com.palantir.conjure"
+                productName = "conjure"
+                minimumVersion = "1.2.0"
+                recommendedVersion = "1.2.0"
+                maximumVersion = "2.x.x"
+            }
+        }
+        '''.stripIndent()
+        when:
+        def result = runTasksSuccessfully(':api:compileConjure')
+
+        then:
+        result.standardOutput.find('Running compiler with args: \\[.*, --extensions, '
+                + '\\{"product-dependencies":\\[\\{'
+                + '"product-group":"com.palantir.conjure",'
+                + '"product-name":"conjure",'
+                + '"minimum-version":"1.2.0",'
+                + '"maximum-version":"2.x.x",'
+                + '"recommended-version":"1.2.0"\\}]\\}]') != null
+    }
+
     def "correctly passes product dependencies to generators"() {
         file('api/build.gradle') << '''
         serviceDependencies {

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/TestVersions.java
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/TestVersions.java
@@ -19,7 +19,7 @@ package com.palantir.gradle.conjure;
 public final class TestVersions {
     private TestVersions() {}
 
-    public static final String CONJURE = "4.6.2";
+    public static final String CONJURE = "4.9.0";
     public static final String CONJURE_JAVA = "5.5.1";
     public static final String CONJURE_PYTHON = "3.11.6";
     public static final String CONJURE_TYPESCRIPT = "3.8.1";


### PR DESCRIPTION
## Before this PR
We only passed product dependency information to the the generators.

## After this PR
Following https://github.com/palantir/conjure/pull/532 we can now add the product dependency information to the IR itself. We'll probably want to update the generators (see Conjure-TS) to take advantage of the extension if present.

We may also want to consider adding other information like name, version, source repository, etc. into the extension for use by generators like Conjure-Java dialogue and Conjure-python
==COMMIT_MSG==
Add product dependency information into produced Conjure IR
==COMMIT_MSG==

## Possible downsides?
N/A

