### PR TITLE
Ensure stderr of conjure IR run is printed it in exception method when it fails

### DIFF
--- a/changelog/@unreleased/pr-384.v2.yml
+++ b/changelog/@unreleased/pr-384.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Error messages produced by conjure IR compilation will not appear in
+    the exception, so at the top of circle builds.
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/384

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
@@ -17,6 +17,7 @@
 package com.palantir.gradle.conjure;
 
 import com.google.common.collect.ImmutableList;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.util.List;
 import java.util.function.Supplier;
@@ -27,6 +28,7 @@ import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.process.ExecResult;
 
 @CacheableTask
 public class CompileIrTask extends DefaultTask {
@@ -67,17 +69,28 @@ public class CompileIrTask extends DefaultTask {
 
     @TaskAction
     public final void generate() {
-        getProject().exec(execSpec -> {
-            ImmutableList.Builder<String> commandArgsBuilder = ImmutableList.builder();
-            commandArgsBuilder.add(
-                    new File(executableDir.get(), EXECUTABLE).getAbsolutePath(),
-                    "compile",
-                    inputDirectory.get().getAbsolutePath(),
-                    outputFile.getAbsolutePath());
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
 
-            List<String> args = commandArgsBuilder.build();
+        ImmutableList.Builder<String> commandArgsBuilder = ImmutableList.builder();
+        commandArgsBuilder.add(
+                new File(executableDir.get(), EXECUTABLE).getAbsolutePath(),
+                "compile",
+                inputDirectory.get().getAbsolutePath(),
+                outputFile.getAbsolutePath());
+
+        List<String> args = commandArgsBuilder.build();
+
+        ExecResult execResult = getProject().exec(execSpec -> {
             getLogger().info("Running compiler with args: {}", args);
             execSpec.commandLine(args.toArray());
+            execSpec.isIgnoreExitValue();
+            execSpec.setStandardOutput(output);
         });
+
+        if (execResult.getExitValue() != 0) {
+            throw new RuntimeException(String.format(
+                    "Failed to generate conjure IR. The command %s failed with exit code %d. Output:\n%s",
+                    args, execResult.getExitValue(), output.toString()));
+        }
     }
 }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
@@ -18,6 +18,7 @@ package com.palantir.gradle.conjure;
 
 import com.google.common.collect.ImmutableList;
 import java.io.File;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 import org.gradle.api.DefaultTask;
@@ -73,6 +74,6 @@ public class CompileIrTask extends DefaultTask {
                 inputDirectory.get().getAbsolutePath(),
                 outputFile.getAbsolutePath());
 
-        GradleExecUtils.exec(getProject(), "generate conjure IR", args);
+        GradleExecUtils.exec(getProject(), "generate conjure IR", Collections.emptyList(), args);
     }
 }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
@@ -69,7 +69,7 @@ public class CompileIrTask extends DefaultTask {
 
     @TaskAction
     public final void generate() {
-        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ByteArrayOutputStream error = new ByteArrayOutputStream();
 
         ImmutableList.Builder<String> commandArgsBuilder = ImmutableList.builder();
         commandArgsBuilder.add(
@@ -84,13 +84,13 @@ public class CompileIrTask extends DefaultTask {
             getLogger().info("Running compiler with args: {}", args);
             execSpec.commandLine(args.toArray());
             execSpec.setIgnoreExitValue(true);
-            execSpec.setStandardOutput(output);
+            execSpec.setErrorOutput(error);
         });
 
         if (execResult.getExitValue() != 0) {
             throw new RuntimeException(String.format(
                     "Failed to generate conjure IR. The command '%s' failed with exit code %d. Output:\n%s",
-                    args, execResult.getExitValue(), output.toString()));
+                    args, execResult.getExitValue(), error.toString()));
         }
     }
 }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
@@ -69,7 +69,7 @@ public class CompileIrTask extends DefaultTask {
 
     @TaskAction
     public final void generate() {
-        ByteArrayOutputStream error = new ByteArrayOutputStream();
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
 
         ImmutableList.Builder<String> commandArgsBuilder = ImmutableList.builder();
         commandArgsBuilder.add(
@@ -84,13 +84,14 @@ public class CompileIrTask extends DefaultTask {
             getLogger().info("Running compiler with args: {}", args);
             execSpec.commandLine(args.toArray());
             execSpec.setIgnoreExitValue(true);
-            execSpec.setErrorOutput(error);
+            execSpec.setStandardOutput(output);
+            execSpec.setErrorOutput(output);
         });
 
         if (execResult.getExitValue() != 0) {
             throw new RuntimeException(String.format(
                     "Failed to generate conjure IR. The command '%s' failed with exit code %d. Output:\n%s",
-                    args, execResult.getExitValue(), error.toString()));
+                    args, execResult.getExitValue(), output.toString()));
         }
     }
 }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
@@ -17,7 +17,6 @@
 package com.palantir.gradle.conjure;
 
 import com.google.common.collect.ImmutableList;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.util.List;
 import java.util.function.Supplier;
@@ -28,7 +27,6 @@ import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.process.ExecResult;
 
 @CacheableTask
 public class CompileIrTask extends DefaultTask {
@@ -69,29 +67,12 @@ public class CompileIrTask extends DefaultTask {
 
     @TaskAction
     public final void generate() {
-        ByteArrayOutputStream output = new ByteArrayOutputStream();
-
-        ImmutableList.Builder<String> commandArgsBuilder = ImmutableList.builder();
-        commandArgsBuilder.add(
+        List<String> args = ImmutableList.of(
                 new File(executableDir.get(), EXECUTABLE).getAbsolutePath(),
                 "compile",
                 inputDirectory.get().getAbsolutePath(),
                 outputFile.getAbsolutePath());
 
-        List<String> args = commandArgsBuilder.build();
-
-        ExecResult execResult = getProject().exec(execSpec -> {
-            getLogger().info("Running compiler with args: {}", args);
-            execSpec.commandLine(args.toArray());
-            execSpec.setIgnoreExitValue(true);
-            execSpec.setStandardOutput(output);
-            execSpec.setErrorOutput(output);
-        });
-
-        if (execResult.getExitValue() != 0) {
-            throw new RuntimeException(String.format(
-                    "Failed to generate conjure IR. The command '%s' failed with exit code %d. Output:\n%s",
-                    args, execResult.getExitValue(), output.toString()));
-        }
+        GradleExecUtils.exec(getProject(), "generate conjure IR", args);
     }
 }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
@@ -89,7 +89,7 @@ public class CompileIrTask extends DefaultTask {
 
         if (execResult.getExitValue() != 0) {
             throw new RuntimeException(String.format(
-                    "Failed to generate conjure IR. The command %s failed with exit code %d. Output:\n%s",
+                    "Failed to generate conjure IR. The command '%s' failed with exit code %d. Output:\n%s",
                     args, execResult.getExitValue(), output.toString()));
         }
     }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
@@ -83,7 +83,7 @@ public class CompileIrTask extends DefaultTask {
         ExecResult execResult = getProject().exec(execSpec -> {
             getLogger().info("Running compiler with args: {}", args);
             execSpec.commandLine(args.toArray());
-            execSpec.isIgnoreExitValue();
+            execSpec.setIgnoreExitValue(true);
             execSpec.setStandardOutput(output);
         });
 

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureGeneratorTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureGeneratorTask.java
@@ -103,15 +103,17 @@ public class ConjureGeneratorTask extends SourceTask {
             GFileUtils.deleteDirectory(thisOutputDirectory);
             getProject().mkdir(thisOutputDirectory);
 
-            List<String> args = ImmutableList.<String>builder()
-                    .add(getExecutablePath().getAbsolutePath())
-                    .add("generate")
-                    .add(file.getAbsolutePath())
-                    .add(thisOutputDirectory.getAbsolutePath())
-                    .addAll(RenderGeneratorOptions.toArgs(getOptions(), requiredOptions(file)))
-                    .build();
+            List<String> generateCommand = ImmutableList.of(
+                    getExecutablePath().getAbsolutePath(),
+                    "generate",
+                    file.getAbsolutePath(),
+                    thisOutputDirectory.getAbsolutePath());
 
-            GradleExecUtils.exec(getProject(), "run generator", args);
+            GradleExecUtils.exec(
+                    getProject(),
+                    "run generator",
+                    generateCommand,
+                    RenderGeneratorOptions.toArgs(getOptions(), requiredOptions(file)));
         });
     }
 

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureGeneratorTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureGeneratorTask.java
@@ -98,23 +98,20 @@ public class ConjureGeneratorTask extends SourceTask {
     /** Entry point for the task. */
     public void compileFiles() {
         getSource().getFiles().forEach(file -> {
-            GeneratorOptions generatorOptions = getOptions();
-            getProject().exec(execSpec -> {
-                ImmutableList.Builder<String> commandArgsBuilder = ImmutableList.builder();
-                File thisOutputDirectory = outputDirectoryFor(file);
-                GFileUtils.deleteDirectory(thisOutputDirectory);
-                getProject().mkdir(thisOutputDirectory);
-                commandArgsBuilder.add(
-                        getExecutablePath().getAbsolutePath(),
-                        "generate",
-                        file.getAbsolutePath(),
-                        thisOutputDirectory.getAbsolutePath());
+            File thisOutputDirectory = outputDirectoryFor(file);
 
-                List<String> additionalArgs = RenderGeneratorOptions.toArgs(generatorOptions, requiredOptions(file));
-                getLogger().info("Running generator with args: {}", additionalArgs);
-                commandArgsBuilder.addAll(additionalArgs);
-                execSpec.commandLine(commandArgsBuilder.build().toArray());
-            });
+            GFileUtils.deleteDirectory(thisOutputDirectory);
+            getProject().mkdir(thisOutputDirectory);
+
+            List<String> args = ImmutableList.<String>builder()
+                    .add(getExecutablePath().getAbsolutePath())
+                    .add("generate")
+                    .add(file.getAbsolutePath())
+                    .add(thisOutputDirectory.getAbsolutePath())
+                    .addAll(RenderGeneratorOptions.toArgs(getOptions(), requiredOptions(file)))
+                    .build();
+
+            GradleExecUtils.exec(getProject(), "run generator", args);
         });
     }
 

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalGeneratorTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalGeneratorTask.java
@@ -94,15 +94,17 @@ public class ConjureJavaLocalGeneratorTask extends SourceTask {
             Map<String, Object> filteredOptions = Maps.filterKeys(
                     generatorOptions, key -> !GENERATOR_FLAGS.contains(key) || generatorFlag.equals(key));
 
-            List<String> args = ImmutableList.<String>builder()
-                    .add(getExecutablePath().getAsFile().get().getAbsolutePath())
-                    .add("generate")
-                    .add(definitionFile.getAbsolutePath())
-                    .add(outputDir.getAbsolutePath())
-                    .addAll(RenderGeneratorOptions.toArgs(filteredOptions, Collections.emptyMap()))
-                    .build();
+            List<String> generateCommand = ImmutableList.of(
+                    getExecutablePath().getAsFile().get().getAbsolutePath(),
+                    "generate",
+                    definitionFile.getAbsolutePath(),
+                    outputDir.getAbsolutePath());
 
-            GradleExecUtils.exec(getProject(), "generate " + generatorFlag, args);
+            GradleExecUtils.exec(
+                    getProject(),
+                    "generate " + generatorFlag,
+                    generateCommand,
+                    RenderGeneratorOptions.toArgs(filteredOptions, Collections.emptyMap()));
         });
     }
 }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalGeneratorTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalGeneratorTask.java
@@ -93,19 +93,16 @@ public class ConjureJavaLocalGeneratorTask extends SourceTask {
             // Need to ensure we don't invoke the generator with two flags from GENERATOR_FLAGS
             Map<String, Object> filteredOptions = Maps.filterKeys(
                     generatorOptions, key -> !GENERATOR_FLAGS.contains(key) || generatorFlag.equals(key));
-            getProject().exec(execSpec -> {
-                ImmutableList.Builder<String> commandArgsBuilder = ImmutableList.builder();
-                commandArgsBuilder.add(
-                        getExecutablePath().getAsFile().get().getAbsolutePath(),
-                        "generate",
-                        definitionFile.getAbsolutePath(),
-                        outputDir.getAbsolutePath());
 
-                List<String> additionalArgs = RenderGeneratorOptions.toArgs(filteredOptions, Collections.emptyMap());
-                getLogger().info("Running generator with args: {}", additionalArgs);
-                commandArgsBuilder.addAll(additionalArgs);
-                execSpec.commandLine(commandArgsBuilder.build().toArray());
-            });
+            List<String> args = ImmutableList.<String>builder()
+                    .add(getExecutablePath().getAsFile().get().getAbsolutePath())
+                    .add("generate")
+                    .add(definitionFile.getAbsolutePath())
+                    .add(outputDir.getAbsolutePath())
+                    .addAll(RenderGeneratorOptions.toArgs(filteredOptions, Collections.emptyMap()))
+                    .build();
+
+            GradleExecUtils.exec(getProject(), "generate " + generatorFlag, args);
         });
     }
 }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GradleExecUtils.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GradleExecUtils.java
@@ -41,7 +41,7 @@ final class GradleExecUtils {
 
         if (execResult.getExitValue() != 0) {
             throw new RuntimeException(String.format(
-                    "Failed to '%s'. The command '%s' failed with exit code %d. Output:\n%s",
+                    "Failed to %s. The command '%s' failed with exit code %d. Output:\n%s",
                     failedTo, loggedArgs, execResult.getExitValue(), output.toString()));
         }
     }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GradleExecUtils.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GradleExecUtils.java
@@ -26,14 +26,16 @@ final class GradleExecUtils {
     private GradleExecUtils() {}
 
     static void exec(Project project, String failedTo, List<String> unloggedArgs, List<String> loggedArgs) {
+        List<String> combinedArgs = ImmutableList.<String>builder()
+                .addAll(unloggedArgs)
+                .addAll(loggedArgs)
+                .build();
+
         ByteArrayOutputStream output = new ByteArrayOutputStream();
 
         ExecResult execResult = project.exec(execSpec -> {
             project.getLogger().info("Running with args: {}", loggedArgs);
-            execSpec.commandLine(ImmutableList.<String>builder()
-                    .addAll(unloggedArgs)
-                    .addAll(loggedArgs)
-                    .build());
+            execSpec.commandLine(combinedArgs);
             execSpec.setIgnoreExitValue(true);
             execSpec.setStandardOutput(output);
             execSpec.setErrorOutput(output);
@@ -42,7 +44,7 @@ final class GradleExecUtils {
         if (execResult.getExitValue() != 0) {
             throw new RuntimeException(String.format(
                     "Failed to %s. The command '%s' failed with exit code %d. Output:\n%s",
-                    failedTo, loggedArgs, execResult.getExitValue(), output.toString()));
+                    failedTo, combinedArgs, execResult.getExitValue(), output.toString()));
         }
     }
 }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GradleExecUtils.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GradleExecUtils.java
@@ -26,6 +26,7 @@ final class GradleExecUtils {
 
     static void exec(Project project, String failedTo, List<String> args) {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
+
         ExecResult execResult = project.exec(execSpec -> {
             project.getLogger().info("Running compiler with args: {}", args);
             execSpec.commandLine(args.toArray());

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GradleExecUtils.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GradleExecUtils.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.conjure;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import org.gradle.api.Project;
+import org.gradle.process.ExecResult;
+
+final class GradleExecUtils {
+    private GradleExecUtils() {}
+
+    static void exec(Project project, String failedTo, List<String> args) {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ExecResult execResult = project.exec(execSpec -> {
+            project.getLogger().info("Running compiler with args: {}", args);
+            execSpec.commandLine(args.toArray());
+            execSpec.setIgnoreExitValue(true);
+            execSpec.setStandardOutput(output);
+            execSpec.setErrorOutput(output);
+        });
+
+        if (execResult.getExitValue() != 0) {
+            throw new RuntimeException(String.format(
+                    "Failed to " + failedTo + ". The command '%s' failed with exit code %d. Output:\n%s",
+                    args, execResult.getExitValue(), output.toString()));
+        }
+    }
+}

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GradleExecUtils.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GradleExecUtils.java
@@ -38,7 +38,9 @@ final class GradleExecUtils {
         if (execResult.getExitValue() != 0) {
             throw new RuntimeException(String.format(
                     "Failed to " + failedTo + ". The command '%s' failed with exit code %d. Output:\n%s",
-                    args, execResult.getExitValue(), output.toString()));
+                    args,
+                    execResult.getExitValue(),
+                    output.toString()));
         }
     }
 }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GradleExecUtils.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GradleExecUtils.java
@@ -28,7 +28,7 @@ final class GradleExecUtils {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
 
         ExecResult execResult = project.exec(execSpec -> {
-            project.getLogger().info("Running compiler with args: {}", args);
+            project.getLogger().info("Running with args: {}", args);
             execSpec.commandLine(args.toArray());
             execSpec.setIgnoreExitValue(true);
             execSpec.setStandardOutput(output);

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GradleExecUtils.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GradleExecUtils.java
@@ -41,10 +41,8 @@ final class GradleExecUtils {
 
         if (execResult.getExitValue() != 0) {
             throw new RuntimeException(String.format(
-                    "Failed to " + failedTo + ". The command '%s' failed with exit code %d. Output:\n%s",
-                    loggedArgs,
-                    execResult.getExitValue(),
-                    output.toString()));
+                    "Failed to '%s'. The command '%s' failed with exit code %d. Output:\n%s",
+                    failedTo, loggedArgs, execResult.getExitValue(), output.toString()));
         }
     }
 }

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureGeneratorTaskTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureGeneratorTaskTest.groovy
@@ -108,4 +108,16 @@ class ConjureGeneratorTaskTest extends IntegrationSpec {
         !fileExists('api/api-objects/src/generated/java/test/test/api/StringExample.java')
         fileExists('api/api-objects/src/generated/java/test/test/api/NewStringExample.java')
     }
+
+    def 'when a file has errors the error is reported in the exception'() {
+        when:
+        file('api/src/main/conjure/bad.yml').text = '''
+            this-is-invalid
+        '''.stripIndent()
+
+        ExecutionResult executionResult = runTasksWithFailure(':api:compileIr')
+
+        then:
+        assert executionResult.failure.cause.cause.message.contains('Cannot construct instance of')
+    }
 }

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPluginIntegrationSpec.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPluginIntegrationSpec.groovy
@@ -80,8 +80,8 @@ class ConjureJavaLocalCodegenPluginIntegrationSpec extends IntegrationSpec {
         result.wasExecuted("conjure-api:generateConjure")
         fileExists("build/conjure-ir/conjure-api.conjure.json")
         fileExists('conjure-api/src/generated/java/test/group/com/palantir/conjure/spec/ConjureDefinition.java')
-        result.standardOutput.contains "Running generator with args: [--jersey, --packagePrefix=test.group]"
-        result.standardOutput.contains "Running generator with args: [--objects, --packagePrefix=test.group]"
+        result.standardOutput.contains "Running with args: [--jersey, --packagePrefix=test.group]"
+        result.standardOutput.contains "Running with args: [--objects, --packagePrefix=test.group]"
     }
 
     def "respects user provided packagePrefix"() {
@@ -101,7 +101,7 @@ class ConjureJavaLocalCodegenPluginIntegrationSpec extends IntegrationSpec {
         then:
         result.wasExecuted("extractConjureIr")
         fileExists('conjure-api/src/generated/java/user/group/com/palantir/conjure/spec/ConjureDefinition.java')
-        result.standardOutput.contains "Running generator with args: [--objects, --packagePrefix=user.group]"
+        result.standardOutput.contains "Running with args: [--objects, --packagePrefix=user.group]"
     }
 
     def 'check code compiles'() {

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalPluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalPluginTest.groovy
@@ -74,7 +74,7 @@ class ConjureLocalPluginTest extends IntegrationSpec {
 
         then:
         result.wasExecuted(":generateJava")
-        result.standardOutput.contains('Running generator with args: [--dialog')
+        result.standardOutput.contains('Running with args: [--dialog')
     }
 
     def "fails to generate java with unsafe options"() {

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/GradleExecUtilsProjectSpec.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/GradleExecUtilsProjectSpec.groovy
@@ -32,10 +32,8 @@ class GradleExecUtilsProjectSpec extends ProjectSpec {
 
         Assertions.assertThatExceptionOfType(RuntimeException).isThrownBy {
             GradleExecUtils.exec(project, 'fail', baseArgs, extraArgs)
-        }.withMessageContaining("""
-            Failed to fail. The command '${baseArgs + extraArgs}' failed with exit code 1. Output:
-            foo
-            bar
-        """.stripIndent().trim())
+        }.withMessageContaining("Failed to fail. The command '${baseArgs + extraArgs}' failed with exit code 1. Output:")
+        .withMessageContaining("foo\n")
+        .withMessageContaining("bar\n")
     }
 }

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/GradleExecUtilsProjectSpec.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/GradleExecUtilsProjectSpec.groovy
@@ -1,0 +1,40 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.conjure
+
+import nebula.test.ProjectSpec
+import org.assertj.core.api.Assertions
+
+class GradleExecUtilsProjectSpec extends ProjectSpec {
+    def 'running a program that exits with code 0 does not throw an exception'() {
+        expect:
+        GradleExecUtils.exec(project, 'execute', ['sh', '-c', 'exit 0'])
+    }
+
+    def 'running a program that exits with a non-zero code throws an exception containing both stdout and stderr'() {
+        expect:
+        def args = ['sh', '-c', 'echo foo; echo bar >&2; exit 1']
+
+        Assertions.assertThatExceptionOfType(RuntimeException).isThrownBy {
+            GradleExecUtils.exec(project, 'fail', args)
+        }.withMessageContaining("""
+            Failed to fail. The command '${args}' failed with exit code 1. Output:
+            foo
+            bar
+        """.stripIndent().trim())
+    }
+}

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/GradleExecUtilsProjectSpec.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/GradleExecUtilsProjectSpec.groovy
@@ -22,17 +22,18 @@ import org.assertj.core.api.Assertions
 class GradleExecUtilsProjectSpec extends ProjectSpec {
     def 'running a program that exits with code 0 does not throw an exception'() {
         expect:
-        GradleExecUtils.exec(project, 'execute', ['sh', '-c', 'exit 0'])
+        GradleExecUtils.exec(project, 'execute', ['sh', '-c'], ['exit 0'])
     }
 
     def 'running a program that exits with a non-zero code throws an exception containing both stdout and stderr'() {
         expect:
-        def args = ['sh', '-c', 'echo foo; echo bar >&2; exit 1']
+        def baseArgs = ['sh', '-c']
+        def extraArgs = ['echo foo; echo bar >&2; exit 1']
 
         Assertions.assertThatExceptionOfType(RuntimeException).isThrownBy {
-            GradleExecUtils.exec(project, 'fail', args)
+            GradleExecUtils.exec(project, 'fail', baseArgs, extraArgs)
         }.withMessageContaining("""
-            Failed to fail. The command '${args}' failed with exit code 1. Output:
+            Failed to fail. The command '${baseArgs + extraArgs}' failed with exit code 1. Output:
             foo
             bar
         """.stripIndent().trim())


### PR DESCRIPTION
## Before this PR
The output of the conjure IR task is not included in the exception when it fails, so you end up with a very not-useful error message:

<img width="863" alt="Screen Shot 2020-02-21 at 2 27 38 PM" src="https://user-images.githubusercontent.com/397795/75042488-6005df00-54b6-11ea-8e6f-555602bb1ca1.png">

## After this PR
==COMMIT_MSG==
Error messages produced by conjure IR compilation will not appear in the exception, so at the top of circle builds.
==COMMIT_MSG==

