### PR TITLE
ConjureJavaLocalCodegenPlugin: ensure packagePrefix doesn't contain dashes

### DIFF
--- a/changelog/@unreleased/pr-392.v2.yml
+++ b/changelog/@unreleased/pr-392.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: '`com.palantir.conjure-java-local` sanitises the maven group to ensure
+    the java package prefix still compiles.'
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/392

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -140,7 +140,8 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
                         Map<String, Object> properties =
                                 new HashMap<>(extension.getJava().getProperties());
                         properties.putIfAbsent(
-                                "packagePrefix", sanitizePackageName(project.getGroup().toString()));
+                                "packagePrefix",
+                                sanitizePackageName(project.getGroup().toString()));
                         return properties;
                     }));
                     task.getOutputDirectory().set(project.file(ConjurePlugin.JAVA_GENERATED_SOURCE_DIRNAME));

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -140,7 +140,7 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
                         Map<String, Object> properties =
                                 new HashMap<>(extension.getJava().getProperties());
                         properties.putIfAbsent(
-                                "packagePrefix", project.getGroup().toString());
+                                "packagePrefix", sanitizePackageName(project.getGroup().toString()));
                         return properties;
                     }));
                     task.getOutputDirectory().set(project.file(ConjurePlugin.JAVA_GENERATED_SOURCE_DIRNAME));
@@ -149,6 +149,14 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
 
         project.getTasks().named("compileJava").configure(compileJava -> compileJava.dependsOn(generateJava));
         ConjurePlugin.applyDependencyForIdeTasks(project, generateJava.get());
+    }
+
+    /**
+     * Maven groups can have dashes, java packages can't.
+     * https://docs.oracle.com/javase/tutorial/java/package/namingpkgs.html.
+     */
+    private static String sanitizePackageName(String group) {
+        return group.replaceAll("-", "");
     }
 
     private static Set<ProductDependency> extractProductDependencies(File irFile) {

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPluginIntegrationSpec.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPluginIntegrationSpec.groovy
@@ -91,7 +91,7 @@ class ConjureJavaLocalCodegenPluginIntegrationSpec extends IntegrationSpec {
         conjure {
             java {
                 addFlag "objects"
-                packagePrefix = "user.group"
+                packagePrefix = "user.some-group"
             }
         }
         """.stripIndent()
@@ -102,8 +102,8 @@ class ConjureJavaLocalCodegenPluginIntegrationSpec extends IntegrationSpec {
 
         then:
         result.wasExecuted("extractConjureIr")
-        fileExists('conjure-api/src/generated/java/user/group/com/palantir/conjure/spec/ConjureDefinition.java')
-        result.standardOutput.contains "Running with args: [--objects, --packagePrefix=user.group]"
+        fileExists('conjure-api/src/generated/java/user/somegroup/com/palantir/conjure/spec/ConjureDefinition.java')
+        result.standardOutput.contains "Running with args: [--objects, --packagePrefix=user.somegroup]"
     }
 
     def 'check code compiles'() {

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPluginIntegrationSpec.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPluginIntegrationSpec.groovy
@@ -65,6 +65,9 @@ class ConjureJavaLocalCodegenPluginIntegrationSpec extends IntegrationSpec {
 
     def "generates projects"() {
         buildFile << """
+        allprojects {
+            group = 'test.group-with-dashes'
+        }
         conjure {
             java {
                 addFlag "jersey"
@@ -81,9 +84,9 @@ class ConjureJavaLocalCodegenPluginIntegrationSpec extends IntegrationSpec {
         result.wasExecuted("extractConjureIr")
         result.wasExecuted("conjure-api:generateConjure")
         fileExists("build/conjure-ir/conjure-api.conjure.json")
-        fileExists('conjure-api/src/generated/java/test/group/com/palantir/conjure/spec/ConjureDefinition.java')
-        result.standardOutput.contains "Running with args: [--jersey, --packagePrefix=test.group]"
-        result.standardOutput.contains "Running with args: [--objects, --packagePrefix=test.group]"
+        fileExists('conjure-api/src/generated/java/test/groupwithdashes/com/palantir/conjure/spec/ConjureDefinition.java')
+        result.standardOutput.contains "Running with args: [--jersey, --packagePrefix=test.groupwithdashes]"
+        result.standardOutput.contains "Running with args: [--objects, --packagePrefix=test.groupwithdashes]"
     }
 
     def "respects user provided packagePrefix"() {
@@ -91,7 +94,7 @@ class ConjureJavaLocalCodegenPluginIntegrationSpec extends IntegrationSpec {
         conjure {
             java {
                 addFlag "objects"
-                packagePrefix = "user.some-group"
+                packagePrefix = "user.group"
             }
         }
         """.stripIndent()
@@ -102,8 +105,8 @@ class ConjureJavaLocalCodegenPluginIntegrationSpec extends IntegrationSpec {
 
         then:
         result.wasExecuted("extractConjureIr")
-        fileExists('conjure-api/src/generated/java/user/somegroup/com/palantir/conjure/spec/ConjureDefinition.java')
-        result.standardOutput.contains "Running with args: [--objects, --packagePrefix=user.somegroup]"
+        fileExists('conjure-api/src/generated/java/user/group/com/palantir/conjure/spec/ConjureDefinition.java')
+        result.standardOutput.contains "Running with args: [--objects, --packagePrefix=user.group]"
     }
 
     def 'check code compiles'() {


### PR DESCRIPTION
## Before this PR

@ferozco ran a script to convert a repo to dialogue and found that conjure-java generated non-compiling code because the package prefix had dashes in it.

## After this PR
==COMMIT_MSG==
`com.palantir.conjure-java-local` sanitises the maven group to ensure the java package prefix still compiles.
==COMMIT_MSG==

Note i've just made sure the _default_ that we pass to conjure-java is sane, people can still choose to pass in whatever they want, but the generated code might no longer compile if they do.

## Possible downsides?


