### PR TITLE
Configure checkUnusedDependencies by task type

### DIFF
--- a/changelog/@unreleased/pr-393.v2.yml
+++ b/changelog/@unreleased/pr-393.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Use a more robust way to configure the `checkUnusedDependencies` tasks
+    for conjure projects.
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/393


### PR DESCRIPTION
## Before this PR

With https://github.com/palantir/gradle-baseline/pull/1262 the existing logic here from #373 will start failing.

## After this PR
==COMMIT_MSG==
Use a more robust way to configure the `checkUnusedDependencies` tasks for conjure projects.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

