### PR TITLE
Ensure IR is downloaded before configuring pdeps

### DIFF
--- a/changelog/@unreleased/pr-397.v2.yml
+++ b/changelog/@unreleased/pr-397.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Ensure that Conjure IR has been downloaded before attempting to configure
+    product dependencies
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/397

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -127,6 +127,7 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
                 irTask -> new File(irTask.getDestinationDir(), project.getName() + ".conjure.json"));
         project.getTasks().named("configureProductDependencies", ConfigureProductDependenciesTask.class, task -> {
             task.setProductDependencies(conjureIrFile.map(ConjureJavaLocalCodegenPlugin::extractProductDependencies));
+            task.dependsOn(extractConjureIr);
         });
 
         TaskProvider<ConjureJavaLocalGeneratorTask> generateJava = project.getTasks()


### PR DESCRIPTION
## Before this PR
Running `--write-locks` would fail to properly update product dependencies since the IR would not be downloaded

## After this PR
==COMMIT_MSG==
Ensure that Conjure IR has been downloaded before attempting to configure product dependencies
==COMMIT_MSG==

## Possible downsides?
N/A
