### PR TITLE
Replace javax.annotation-api with jakarta.annoatation-api

### DIFF
--- a/changelog/@unreleased/pr-399.v2.yml
+++ b/changelog/@unreleased/pr-399.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Replace `javax.annotation-api` with `jakarta.annotation-api` as default
+    dependency on java projects
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/399

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -98,7 +98,7 @@ public final class ConjurePlugin implements Plugin<Project> {
 
     static final String CONJURE_GENERATOR_DEP_PREFIX = "conjure-";
     /** Make the old Java8 @Generated annotation available even when compiling with Java9+. */
-    static final String ANNOTATION_API = "javax.annotation:javax.annotation-api:1.3.2";
+    static final String ANNOTATION_API = "jakarta.annotation:jakarta.annotation-api:1.3.5";
 
     @Override
     public void apply(Project project) {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
==COMMIT_MSG==
Replace `javax.annotation-api` with `jakarta.annotation-api` as default dependency on 
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

