### PR TITLE
Produce `rawIr` task

### DIFF
--- a/changelog/@unreleased/pr-417.v2.yml
+++ b/changelog/@unreleased/pr-417.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Expose `rawIr` task which produces the raw IR without any extensions.
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/417

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
@@ -66,6 +66,7 @@ public class CompileIrTask extends DefaultTask {
     }
 
     @OutputFile
+    @PathSensitive(PathSensitivity.NONE)
     public final RegularFileProperty getOutputIrFile() {
         return outputIrFile;
     }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
@@ -37,24 +38,40 @@ import org.gradle.api.tasks.TaskAction;
 @CacheableTask
 public class CompileIrTask extends DefaultTask {
     private static final String EXECUTABLE = OsUtils.appendDotBatIfWindows("bin/conjure");
+    private final RegularFileProperty outputIrFile = getProject().getObjects().fileProperty();
 
-    private File outputFile;
     private Supplier<File> inputDirectory;
     private Supplier<File> executableDir;
     private final SetProperty<ServiceDependency> productDependencies =
             getProject().getObjects().setProperty(ServiceDependency.class);
 
+    /**
+     * Eagerly set where to output the generated IR.
+     *
+     * @deprecated Use {@link #getOutputIrFile()} instead.
+     */
+    @Deprecated
     public final void setOutputFile(File outputFile) {
-        this.outputFile = outputFile;
+        outputIrFile.set(outputFile);
+    }
+
+    /**
+     * Eagerly get where to output the generated IR.
+     *
+     * @deprecated Use {@link #getOutputIrFile()} instead.
+     */
+    @Deprecated
+    public final File getOutputFile() {
+        return outputIrFile.getAsFile().get();
+    }
+
+    @OutputFile
+    public final RegularFileProperty getOutputIrFile() {
+        return outputIrFile;
     }
 
     public final void setInputDirectory(Supplier<File> inputDirectory) {
         this.inputDirectory = inputDirectory;
-    }
-
-    @OutputFile
-    public final File getOutputFile() {
-        return outputFile;
     }
 
     @InputDirectory
@@ -84,7 +101,7 @@ public class CompileIrTask extends DefaultTask {
                 new File(executableDir.get(), EXECUTABLE).getAbsolutePath(),
                 "compile",
                 inputDirectory.get().getAbsolutePath(),
-                outputFile.getAbsolutePath(),
+                outputIrFile.get().getAsFile().getAbsolutePath(),
                 "--extensions",
                 getSerializedExtensions());
 

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePublishPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePublishPlugin.java
@@ -42,7 +42,7 @@ public final class ConjurePublishPlugin implements Plugin<Project> {
                 publications.create(
                         "conjure",
                         MavenPublication.class,
-                        mavenPublication -> mavenPublication.artifact(compileIr.getOutputFile(), mavenArtifact -> {
+                        mavenPublication -> mavenPublication.artifact(compileIr.getOutputIrFile(), mavenArtifact -> {
                             mavenArtifact.builtBy(compileIr);
                             mavenArtifact.setExtension("conjure.json");
                         }));


### PR DESCRIPTION
## Before this PR
It was not possible to get the Conjure IR without resolving the product dependencies, making automatic verification of product dependencies difficult. 

## After this PR
==COMMIT_MSG==
Expose `rawIr` task which produces the raw IR without any extensions.
==COMMIT_MSG==

## Possible downsides?
N/A

