### PR TITLE
Fix bad advice

### DIFF
--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
@@ -66,7 +66,6 @@ public class CompileIrTask extends DefaultTask {
     }
 
     @OutputFile
-    @PathSensitive(PathSensitivity.NONE)
     public final RegularFileProperty getOutputIrFile() {
         return outputIrFile;
     }


### PR DESCRIPTION
## Before this PR

Made it throw a deprecation  warning in gradle 6 in #417

## After this PR
==COMMIT_MSG==
Fix deprecation warning with gradle 6 for `rawIr` and `compileIr`.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

