### PR TITLE
Install NPM dependencies with the --no-production flag

### DIFF
--- a/changelog/@unreleased/pr-426.v2.yml
+++ b/changelog/@unreleased/pr-426.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Always specify the `--no-production` flag when installing dependencies
+    to ignore `NODE_ENV` and ensure that dev dependencies such as TypeScript are installed
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/426

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -464,7 +464,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                 String npmCommand = OsUtils.NPM_COMMAND_NAME;
                 Task installTypeScriptDependencies = project.getTasks()
                         .create("installTypeScriptDependencies", Exec.class, task -> {
-                            task.commandLine(npmCommand, "install", "--no-package-lock");
+                            task.commandLine(npmCommand, "install", "--no-package-lock", "--no-production");
                             task.workingDir(srcDirectory);
                             task.dependsOn(compileConjureTypeScript);
                             task.getInputs().file(new File(srcDirectory, "package.json"));


### PR DESCRIPTION
## Before this PR
Setting `NODE_ENV=production` causes dev dependencies such as TypeScript to not be installed. This causes the `compileTypeScript` task to fail with `tsc: not found`  

## After this PR
==COMMIT_MSG==
Always specify the `--no-production` flag when installing dependencies to ignore `NODE_ENV`. For our use case we always want to install dev dependencies. 
==COMMIT_MSG==

## Possible downsides?
None that I can think of. 

