### PR TITLE
Make recommendedVersion optional

### DIFF
--- a/changelog/@unreleased/pr-432.v2.yml
+++ b/changelog/@unreleased/pr-432.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '`recommendedVersion` is no longer required.'
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/432

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GenerateConjureServiceDependenciesTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GenerateConjureServiceDependenciesTask.java
@@ -77,18 +77,22 @@ public class GenerateConjureServiceDependenciesTask extends DefaultTask {
                 NAME_PATTERN.matcher(serviceDependency.getProductName()).matches(),
                 "productName must be a valid maven name");
         Preconditions.checkNotNull(serviceDependency.getMinimumVersion(), "minimum version must be specified");
-        if (!SlsVersion.check(serviceDependency.getMaximumVersion())
-                && !SlsVersionMatcher.safeValueOf(serviceDependency.getMaximumVersion())
-                        .isPresent()) {
+        Preconditions.checkNotNull(serviceDependency.getMaximumVersion(), "maximum version must be specified");
+        if (!SlsVersionMatcher.safeValueOf(serviceDependency.getMaximumVersion())
+                .isPresent()) {
             throw new IllegalArgumentException("maximumVersion must be valid SLS version or version matcher: "
                     + serviceDependency.getMaximumVersion());
-        } else if (!SlsVersion.check(serviceDependency.getMinimumVersion())) {
+        }
+        if (!SlsVersion.check(serviceDependency.getMinimumVersion())) {
             throw new IllegalArgumentException(
-                    "minimumVersion must be valid SLS versions: " + serviceDependency.getMinimumVersion());
-        } else if (!SlsVersion.check(serviceDependency.getRecommendedVersion())) {
+                    "minimumVersion must be valid SLS version: " + serviceDependency.getMinimumVersion());
+        }
+        if (serviceDependency.getRecommendedVersion() != null
+                && !SlsVersion.check(serviceDependency.getRecommendedVersion())) {
             throw new IllegalArgumentException(
-                    "recommendedVersion must be valid SLS versions: " + serviceDependency.getRecommendedVersion());
-        } else if (serviceDependency.getMinimumVersion().equals(serviceDependency.getMaximumVersion())) {
+                    "recommendedVersion must be valid SLS version: " + serviceDependency.getRecommendedVersion());
+        }
+        if (serviceDependency.getMinimumVersion().equals(serviceDependency.getMaximumVersion())) {
             throw new SafeIllegalArgumentException("minimumVersion and maximumVersion must be different");
         }
     }


### PR DESCRIPTION
## Before this PR
`recommendedVersion` is required. If it is omitted, the following exception will be thrown:
```
com.palantir.logsafe.exceptions.SafeNullPointerException: value cannot be null
	at com.palantir.logsafe.Preconditions.checkNotNull(Preconditions.java:210)
	at com.palantir.sls.versions.OrderableSlsVersion.safeValueOf(OrderableSlsVersion.java:54)
	at com.palantir.sls.versions.SlsVersion.valueOf(SlsVersion.java:31)
	at com.palantir.sls.versions.SlsVersion.check(SlsVersion.java:46)
	at com.palantir.gradle.conjure.GenerateConjureServiceDependenciesTask.validateServiceDependency(GenerateConjureServiceDependenciesTask.java:88)
```

## After this PR
`recommendedVersion` is not required.

