### PR TITLE
Handle applying gradle-conjure to the root

### DIFF
--- a/changelog/@unreleased/pr-477.v2.yml
+++ b/changelog/@unreleased/pr-477.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Handle applying gradle-conjure to the root
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/477

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -558,8 +558,9 @@ public final class ConjurePlugin implements Plugin<Project> {
             Configuration conjureGeneratorsConfiguration) {
         Map<String, Project> genericSubProjects = Maps.filterKeys(
                 project.getChildProjects(),
-                key -> !FIRST_CLASS_GENERATOR_PROJECT_NAMES.contains(
-                        extractSubprojectLanguage(project.getName(), key)));
+                childProjectName -> childProjectName.startsWith(project.getName())
+                        && !FIRST_CLASS_GENERATOR_PROJECT_NAMES.contains(
+                                extractSubprojectLanguage(project.getName(), childProjectName)));
         if (genericSubProjects.isEmpty()) {
             return;
         }


### PR DESCRIPTION
## Before this PR
We would throw an index out of bound exception if gradle conjure was applied to a project that had child projects that had a name that did not start with the  parent projects name

## After this PR
==COMMIT_MSG==
Handle applying gradle-conjure to the root
==COMMIT_MSG==

## Possible downsides?
N/A

