### PR TITLE
fix one deprecation warning

### DIFF
--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
@@ -30,6 +30,7 @@ import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
@@ -61,6 +62,7 @@ public class CompileIrTask extends DefaultTask {
      * @deprecated Use {@link #getOutputIrFile()} instead.
      */
     @Deprecated
+    @Internal
     public final File getOutputFile() {
         return outputIrFile.getAsFile().get();
     }


### PR DESCRIPTION
I tried running `./gradlew classes --warning-mode=all` and saw this:

```
> Task :log-receiver-api:rawIr UP-TO-DATE
Property 'outputFile' is not annotated with an input or output annotation. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/6.6-20200526220100+0000/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
```