### PR TITLE
expose conjureIr via consumable configuration

### DIFF
--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureBasePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureBasePlugin.java
@@ -94,7 +94,7 @@ public final class ConjureBasePlugin implements Plugin<Project> {
             compileIr.getProductDependencies().set(project.provider(pdepsExtension::getProductDependencies));
             compileIr.dependsOn(copyConjureSourcesTask);
             compileIr.dependsOn(extractCompilerTask);
-            
+
             project.getConfigurations().create(CONJURE_IR_CONFIGURATION, conf -> {
                 conf.setCanBeResolved(false);
             });

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureBasePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureBasePlugin.java
@@ -24,6 +24,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.attributes.Attribute;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.plugins.BasePlugin;
@@ -36,6 +37,8 @@ import org.gradle.util.GFileUtils;
 public final class ConjureBasePlugin implements Plugin<Project> {
     static final String COMPILE_IR_TASK = "compileIr";
     static final String SERVICE_DEPENDENCIES_TASK = "generateConjureServiceDependencies";
+
+    static final Attribute<String> API_ATTRIBUTE = Attribute.of("com.palantir.api.type", String.class);
 
     static final String CONJURE_IR_CONFIGURATION = "conjureIr";
     static final String CONJURE_COMPILER = "conjureCompiler";
@@ -97,6 +100,7 @@ public final class ConjureBasePlugin implements Plugin<Project> {
 
             project.getConfigurations().create(CONJURE_IR_CONFIGURATION, conf -> {
                 conf.setCanBeResolved(false);
+                conf.attributes(attributeContainer -> attributeContainer.attribute(API_ATTRIBUTE, "conjure"));
             });
             project.artifacts(artifactHandler -> {
                 artifactHandler.add(

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureBasePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureBasePlugin.java
@@ -37,6 +37,7 @@ public final class ConjureBasePlugin implements Plugin<Project> {
     static final String COMPILE_IR_TASK = "compileIr";
     static final String SERVICE_DEPENDENCIES_TASK = "generateConjureServiceDependencies";
 
+    static final String CONJURE_IR_CONFIGURATION = "conjureIr";
     static final String CONJURE_COMPILER = "conjureCompiler";
     static final String CONJURE_COMPILER_BINARY = "com.palantir.conjure:conjure";
 
@@ -93,6 +94,11 @@ public final class ConjureBasePlugin implements Plugin<Project> {
             compileIr.getProductDependencies().set(project.provider(pdepsExtension::getProductDependencies));
             compileIr.dependsOn(copyConjureSourcesTask);
             compileIr.dependsOn(extractCompilerTask);
+            
+            project.getConfigurations().maybeCreate(CONJURE_IR_CONFIGURATION);
+            project.artifacts(artifactHandler -> {
+                artifactHandler.add(CONJURE_IR_CONFIGURATION, compileIr.getOutputIrFile());
+            });
         });
     }
 

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureBasePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureBasePlugin.java
@@ -95,9 +95,12 @@ public final class ConjureBasePlugin implements Plugin<Project> {
             compileIr.dependsOn(copyConjureSourcesTask);
             compileIr.dependsOn(extractCompilerTask);
             
-            project.getConfigurations().maybeCreate(CONJURE_IR_CONFIGURATION);
+            project.getConfigurations().create(CONJURE_IR_CONFIGURATION, conf -> {
+                conf.setCanBeResolved(false);
+            });
             project.artifacts(artifactHandler -> {
-                artifactHandler.add(CONJURE_IR_CONFIGURATION, compileIr.getOutputIrFile());
+                artifactHandler.add(
+                        CONJURE_IR_CONFIGURATION, compileIr.getOutputIrFile(), artifact -> artifact.builtBy(compileIr));
             });
         });
     }


### PR DESCRIPTION
## Before this PR
Internal infrastructure needs to hook into the IRs produced for a subset of the Java projects in a repository. Once the relevant Java projects are specified, this will allow that infrastructure to grab the relevant IRs.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Expose the IRs produced by the compileIr task via a consumable configuration.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

