### PR TITLE
feature: produce consumable configuration with conjureIR

### DIFF
--- a/changelog/@unreleased/pr-572.v2.yml
+++ b/changelog/@unreleased/pr-572.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Expose consumable configuration with `Usage` `conjure` that contains
+    the complete IR of the conjure project
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/572

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureBasePluginIntegrationSpec.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureBasePluginIntegrationSpec.groovy
@@ -1,0 +1,136 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.conjure
+
+import java.nio.file.Files
+import nebula.test.IntegrationSpec
+import nebula.test.functional.ExecutionResult
+import org.gradle.util.GFileUtils
+
+class ConjureBasePluginIntegrationSpec extends IntegrationSpec {
+    private static final String API_YML = """
+    types:
+      definitions:
+        default-package: test.test.api
+        objects:
+          StringExample:
+            fields:
+              string: string
+    """.stripIndent()
+
+    def setup() {
+        buildFile << """
+        allprojects {
+            ${applyPlugin(ConjureBasePlugin)}
+            version '0.1.0'
+            group 'com.palantir.conjure.test'
+
+            repositories {
+                mavenCentral()
+                maven { url 'https://dl.bintray.com/palantir/releases/' }
+            }
+
+            configurations.all {
+                resolutionStrategy {
+                    force 'com.palantir.conjure:conjure:${TestVersions.CONJURE}'
+                }
+            }
+        }
+        """.stripIndent()
+    }
+
+    def 'compile conjure'() {
+        when:
+        file('src/main/conjure/api.yml') << API_YML
+
+        then:
+        runTasksSuccessfully('compileIr')
+        file("build/conjure-ir/${moduleName}.conjure.json")
+    }
+
+    def 'correctly caches compilation'() {
+        when:
+        file('src/main/conjure/api.yml') << API_YML
+
+        then:
+        def result1 = runTasksSuccessfully('compileIr')
+        result1.wasExecuted('extractConjure')
+        result1.wasExecuted('compileIr')
+        def result2 = runTasksSuccessfully('compileIr')
+        result2.wasUpToDate('extractConjure')
+        result2.wasUpToDate('compileIr')
+    }
+
+    def 'fails to compile invalid conjure'() {
+        when:
+        file('src/main/conjure/api.yml') << "foo"
+
+        then:
+        runTasksWithFailure('compileIr')
+    }
+
+    def 'compileIr can get results from the build cache'() {
+        def localBuildCache = Files.createDirectories(projectDir.toPath().resolve("local-build-cache"))
+        settingsFile << """
+        buildCache {
+            local {
+                directory = file("${localBuildCache}")
+                enabled = true
+            }
+        }
+        """.stripIndent()
+        file("gradle.properties") << "\norg.gradle.caching = true\n"
+
+        when:
+        file('src/main/conjure/api.yml') << API_YML
+
+        runTasksSuccessfully('compileIr')
+        GFileUtils.deleteDirectory(projectDir.toPath().resolve("build").toFile())
+        ExecutionResult result = runTasksSuccessfully('compileIr', '-i')
+
+        then:
+        result.standardOutput.contains "Task :compileIr FROM-CACHE"
+    }
+
+    def 'conjure project produces consumable configuration'() {
+        when:
+        addSubproject("conjure-api", "apply plugin: 'java'")
+        file('conjure-api/src/main/conjure/api.yml') << API_YML
+
+        addSubproject("api-consumer", '''
+        configurations {
+            irConsumer {
+                attributes.attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage.class, "conjure"));
+            }
+        }
+
+        dependencies {
+            irConsumer project(':conjure-api')
+        }
+        
+        task getIr(type: Copy) {
+            from configurations.irConsumer
+            into "${project.buildDir}/all-ir"
+        }
+        '''.stripIndent())
+
+        then:
+        def result = runTasksSuccessfully('getIr')
+        result.wasExecuted(':conjure-api:compileIr')
+        file("build/all-ir/conjure-api.conjure.json")
+    }
+}


### PR DESCRIPTION
## Before this PR
It was hard for other plugins to consume the Conjure IR across projects and doing so forced them to depend on implementation details of the plugin.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Expose consumable configuration with `Usage` `conjure` that contains the complete IR of the conjure project
==COMMIT_MSG==

## Possible downsides?
N/A

