### PR TITLE
Escape and wrap compileIr task argument for Windows

### DIFF
--- a/changelog/@unreleased/pr-597.v2.yml
+++ b/changelog/@unreleased/pr-597.v2.yml
@@ -1,5 +1,5 @@
 type: fix
-feature:
+fix:
   description: Gradle was unable to build the Conjure IR file due to invalid escaping of the command line options. This
   PR ensures that the CLI options are escaped when running on Windows systems.
   links:

--- a/changelog/@unreleased/pr-597.v2.yml
+++ b/changelog/@unreleased/pr-597.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+feature:
+  description: Gradle was unable to build the Conjure IR file due to invalid escaping of the command line options. This
+  PR ensures that the CLI options are escaped when running on Windows systems.
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/597

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileIrTask.java
@@ -105,7 +105,7 @@ public class CompileIrTask extends DefaultTask {
                 inputDirectory.get().getAbsolutePath(),
                 outputIrFile.get().getAsFile().getAbsolutePath(),
                 "--extensions",
-                getSerializedExtensions());
+                OsUtils.escapeAndWrapArgIfWindows(getSerializedExtensions()));
 
         GradleExecUtils.exec(getProject(), "generate conjure IR", Collections.emptyList(), args);
     }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/OsUtils.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/OsUtils.java
@@ -32,6 +32,10 @@ final class OsUtils {
         return new File(appendDotBatIfWindows(executable.getPath()));
     }
 
+    static String escapeAndWrapArgIfWindows(String argument) {
+        return Os.isFamily(Os.FAMILY_WINDOWS) ? ("\"" + argument.replaceAll("\"", "\"\"") + "\"") : argument;
+    }
+
     private static String appendIfWindows(String toAppend, String value) {
         return value + (Os.isFamily(Os.FAMILY_WINDOWS) ? toAppend : "");
     }


### PR DESCRIPTION
## Before this PR
When running the `compileIr` task on Windows systems, we receive an error due to the extensions argument of the command not being properly wrapped and escaped for the Windows .bat command. The stack trace for this issue can be found here: https://github.com/palantir/gradle-conjure/issues/594

## After this PR
Windows systems will be able to successfully compile Conjure products.
Update compileIr task to handle escaping command line arguments for Windows

## Possible downsides?
I'm not sure the compileConjure task has been working properly with Windows for a while. Cloning the most recent Conjure Java Example project (https://github.com/palantir/conjure-java-example) fails to build on Windows. I've tested this on numerous machines so it seems to be specific to the Conjure project.

