### PR TITLE
Centralize generator extraction onto the root project

### DIFF
--- a/changelog/@unreleased/pr-684.v2.yml
+++ b/changelog/@unreleased/pr-684.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Several standard generators are extracted to the project root
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/684

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureBasePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureBasePlugin.java
@@ -42,8 +42,6 @@ public final class ConjureBasePlugin implements Plugin<Project> {
     static final String SERVICE_DEPENDENCIES_TASK = "generateConjureServiceDependencies";
 
     static final String CONJURE_IR_CONFIGURATION = "conjureIr";
-    static final String CONJURE_COMPILER = "conjureCompiler";
-    static final String CONJURE_COMPILER_BINARY = "com.palantir.conjure:conjure";
 
     static final String TASK_GROUP = "Conjure";
 
@@ -74,8 +72,7 @@ public final class ConjureBasePlugin implements Plugin<Project> {
             Project project,
             ConjureProductDependenciesExtension pdepsExtension,
             TaskProvider<Copy> copyConjureSourcesTask) {
-        ExtractExecutableTask extractCompilerTask = ExtractExecutableTask.getOrCreateExtractTaskOnRootProject(
-                project, "extractConjure", "conjure", CONJURE_COMPILER, CONJURE_COMPILER_BINARY);
+        ExtractExecutableTask extractCompilerTask = ExtractConjurePlugin.applyConjureCompiler(project);
 
         Provider<Directory> irDir = project.getLayout().getBuildDirectory().dir("conjure-ir");
 

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureBasePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureBasePlugin.java
@@ -74,11 +74,8 @@ public final class ConjureBasePlugin implements Plugin<Project> {
             Project project,
             ConjureProductDependenciesExtension pdepsExtension,
             TaskProvider<Copy> copyConjureSourcesTask) {
-        Configuration conjureCompilerConfig = project.getConfigurations().maybeCreate(CONJURE_COMPILER);
-        File conjureCompilerDir = new File(project.getBuildDir(), CONJURE_COMPILER);
-        project.getDependencies().add(CONJURE_COMPILER, CONJURE_COMPILER_BINARY);
-        ExtractExecutableTask extractCompilerTask = ExtractExecutableTask.createExtractTask(
-                project, "extractConjure", conjureCompilerConfig, conjureCompilerDir, "conjure");
+        ExtractExecutableTask extractCompilerTask = ExtractExecutableTask.getOrCreateExtractTaskOnRootProject(
+                project, "extractConjure", "conjure", CONJURE_COMPILER, CONJURE_COMPILER_BINARY);
 
         Provider<Directory> irDir = project.getLayout().getBuildDirectory().dir("conjure-ir");
 

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -49,9 +49,6 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
     private static final Pattern DEFINITION_NAME =
             Pattern.compile("(.*)-([0-9]+\\.[0-9]+\\.[0-9]+(?:-rc[0-9]+)?(?:-[0-9]+-g[a-f0-9]+)?)(\\.conjure)?\\.json");
 
-    static final String CONJURE_JAVA = "conjureJava";
-    static final String CONJURE_JAVA_BINARY = "com.palantir.conjure.java:conjure-java";
-
     @Override
     public void apply(Project project) {
         project.getPlugins().apply(JavaBasePlugin.class);
@@ -66,11 +63,7 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
             task.into(project.getLayout().getBuildDirectory().dir("conjure-ir"));
         });
 
-        Configuration conjureJavaConfig = project.getConfigurations().create(CONJURE_JAVA);
-        File conjureJavaDir = new File(project.getBuildDir(), CONJURE_JAVA);
-        project.getDependencies().add(CONJURE_JAVA, CONJURE_JAVA_BINARY);
-        ExtractExecutableTask extractJavaTask = ExtractExecutableTask.createExtractTask(
-                project, "extractConjureJava", conjureJavaConfig, conjureJavaDir, "conjure-java");
+        ExtractExecutableTask extractJavaTask = ExtractConjurePlugin.applyConjureJava(project);
 
         setupSubprojects(project, extension, extractJavaTask, extractConjureIr, conjureIrConfiguration);
     }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
@@ -83,11 +83,7 @@ public final class ConjureLocalPlugin implements Plugin<Project> {
             return;
         }
 
-        Configuration conjureJavaConfig = project.getConfigurations().maybeCreate(ConjurePlugin.CONJURE_JAVA);
-        File conjureJavaDir = new File(project.getBuildDir(), ConjurePlugin.CONJURE_JAVA);
-        project.getDependencies().add(ConjurePlugin.CONJURE_JAVA, ConjurePlugin.CONJURE_JAVA_BINARY);
-        ExtractExecutableTask extractJavaTask = ExtractExecutableTask.createExtractTask(
-                project, "extractConjureJava", conjureJavaConfig, conjureJavaDir, "conjure-java");
+        ExtractExecutableTask extractJavaTask = ExtractConjurePlugin.applyConjureJava(project);
 
         subproj.getPluginManager().apply(JavaLibraryPlugin.class);
         ConjurePlugin.addGeneratedToMainSourceSet(subproj);
@@ -204,13 +200,8 @@ public final class ConjureLocalPlugin implements Plugin<Project> {
         if (subproj == null) {
             return;
         }
-        Configuration conjurePythonConfig = project.getConfigurations().maybeCreate(ConjurePlugin.CONJURE_PYTHON);
 
-        File conjurePythonDir = new File(project.getBuildDir(), ConjurePlugin.CONJURE_PYTHON);
-        project.getDependencies().add(ConjurePlugin.CONJURE_PYTHON, ConjurePlugin.CONJURE_PYTHON_BINARY);
-
-        ExtractExecutableTask extractConjurePythonTask = ExtractExecutableTask.createExtractTask(
-                project, "extractConjurePython", conjurePythonConfig, conjurePythonDir, "conjure-python");
+        ExtractExecutableTask extractConjurePythonTask = ExtractConjurePlugin.applyConjurePython(project);
 
         project.getTasks().create("generatePython", ConjureLocalGenerateTask.class, task -> {
             task.setDescription("Generates Python files from remote Conjure definitions.");
@@ -233,18 +224,9 @@ public final class ConjureLocalPlugin implements Plugin<Project> {
         if (subproj == null) {
             return;
         }
-        Configuration conjureTypeScriptConfig =
-                project.getConfigurations().maybeCreate(ConjurePlugin.CONJURE_TYPESCRIPT);
-        File conjureTypescriptDir = new File(project.getBuildDir(), ConjurePlugin.CONJURE_TYPESCRIPT);
         File srcDirectory = subproj.file("src");
-        project.getDependencies().add(ConjurePlugin.CONJURE_TYPESCRIPT, ConjurePlugin.CONJURE_TYPESCRIPT_BINARY);
 
-        ExtractExecutableTask extractConjureTypeScriptTask = ExtractExecutableTask.createExtractTask(
-                project,
-                "extractConjureTypeScript",
-                conjureTypeScriptConfig,
-                conjureTypescriptDir,
-                "conjure-typescript");
+        ExtractExecutableTask extractConjureTypeScriptTask = ExtractConjurePlugin.applyConjureTypeScript(project);
 
         project.getTasks().create("generateTypeScript", ConjureLocalGenerateTask.class, task -> {
             task.setDescription("Generate Typescript bindings from remote Conjure definitions.");

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ExtractConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ExtractConjurePlugin.java
@@ -1,0 +1,113 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.conjure;
+
+import java.io.File;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+
+abstract class ExtractConjurePlugin implements Plugin<Project> {
+
+    // configuration names
+    static final String CONJURE_COMPILER = "conjureCompiler";
+    static final String CONJURE_TYPESCRIPT = "conjureTypeScript";
+    static final String CONJURE_PYTHON = "conjurePython";
+    static final String CONJURE_JAVA = "conjureJava";
+
+    // executable distributions
+    static final String CONJURE_COMPILER_BINARY = "com.palantir.conjure:conjure";
+    static final String CONJURE_JAVA_BINARY = "com.palantir.conjure.java:conjure-java";
+    static final String CONJURE_TYPESCRIPT_BINARY = "com.palantir.conjure.typescript:conjure-typescript@tgz";
+    static final String CONJURE_PYTHON_BINARY = "com.palantir.conjure.python:conjure-python";
+
+    private final String taskName;
+    private final String executableName;
+    private final String configurationName;
+    private final String dependency;
+
+    protected ExtractConjurePlugin(
+            String taskName, String executableName, String configurationName, String dependency) {
+        this.taskName = taskName;
+        this.executableName = executableName;
+        this.configurationName = configurationName;
+        this.dependency = dependency;
+    }
+
+    @Override
+    public final void apply(Project project) {
+        Configuration configuration = project.getConfigurations().maybeCreate(configurationName);
+        File outputDir = new File(project.getBuildDir(), configurationName);
+        project.getDependencies().add(configurationName, dependency);
+        ExtractExecutableTask.createExtractTask(project, taskName, configuration, outputDir, executableName);
+    }
+
+    static ExtractExecutableTask applyConjureCompiler(Project project) {
+        return applyAndGet(project, ExtractConjureCompilerPlugin.class, ExtractConjureCompilerPlugin.TASK_NAME);
+    }
+
+    static ExtractExecutableTask applyConjureJava(Project project) {
+        return applyAndGet(project, ExtractConjureJavaPlugin.class, ExtractConjureJavaPlugin.TASK_NAME);
+    }
+
+    static ExtractExecutableTask applyConjureTypeScript(Project project) {
+        return applyAndGet(project, ExtractConjureTypeScriptPlugin.class, ExtractConjureTypeScriptPlugin.TASK_NAME);
+    }
+
+    static ExtractExecutableTask applyConjurePython(Project project) {
+        return applyAndGet(project, ExtractConjurePythonPlugin.class, ExtractConjurePythonPlugin.TASK_NAME);
+    }
+
+    private static ExtractExecutableTask applyAndGet(
+            Project provided, Class<? extends Plugin<? extends Project>> plugin, String name) {
+        Project project = provided.getRootProject();
+        project.getPluginManager().apply(plugin);
+        return (ExtractExecutableTask) project.getTasks().getByName(name);
+    }
+
+    static final class ExtractConjureCompilerPlugin extends ExtractConjurePlugin {
+        static final String TASK_NAME = "extractConjure";
+
+        ExtractConjureCompilerPlugin() {
+            super(TASK_NAME, "conjure", CONJURE_COMPILER, CONJURE_COMPILER_BINARY);
+        }
+    }
+
+    static final class ExtractConjureJavaPlugin extends ExtractConjurePlugin {
+        static final String TASK_NAME = "extractConjureJava";
+
+        ExtractConjureJavaPlugin() {
+            super(TASK_NAME, "conjure-java", CONJURE_JAVA, CONJURE_JAVA_BINARY);
+        }
+    }
+
+    static final class ExtractConjureTypeScriptPlugin extends ExtractConjurePlugin {
+        static final String TASK_NAME = "extractConjureTypeScript";
+
+        ExtractConjureTypeScriptPlugin() {
+            super(TASK_NAME, "conjure-typescript", CONJURE_TYPESCRIPT, CONJURE_TYPESCRIPT_BINARY);
+        }
+    }
+
+    static final class ExtractConjurePythonPlugin extends ExtractConjurePlugin {
+        static final String TASK_NAME = "extractConjurePython";
+
+        ExtractConjurePythonPlugin() {
+            super(TASK_NAME, "conjure-python", CONJURE_PYTHON, CONJURE_PYTHON_BINARY);
+        }
+    }
+}

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ExtractExecutableTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ExtractExecutableTask.java
@@ -108,7 +108,7 @@ public class ExtractExecutableTask extends Sync {
     }
 
     public static synchronized ExtractExecutableTask getOrCreateExtractTaskOnRootProject(
-            Project input, String taskName, String executableName, String configurationName, String dependency) {
+            Project input, String taskName, String executableName, String configurationName, Object dependency) {
         Project rootProject = input.getRootProject();
         TaskContainer tasks = rootProject.getTasks();
         Task existing = tasks.findByName(taskName);

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ExtractExecutableTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ExtractExecutableTask.java
@@ -30,7 +30,6 @@ import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.file.FileVisitDetails;
@@ -41,7 +40,6 @@ import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.Sync;
-import org.gradle.api.tasks.TaskContainer;
 
 public class ExtractExecutableTask extends Sync {
     private FileCollection archive;
@@ -105,20 +103,6 @@ public class ExtractExecutableTask extends Sync {
             task.setOutputDirectory(outputDir);
             task.setExecutableName(executableName);
         });
-    }
-
-    public static synchronized ExtractExecutableTask getOrCreateExtractTaskOnRootProject(
-            Project input, String taskName, String executableName, String configurationName, Object dependency) {
-        Project rootProject = input.getRootProject();
-        TaskContainer tasks = rootProject.getTasks();
-        Task existing = tasks.findByName(taskName);
-        if (existing != null) {
-            return (ExtractExecutableTask) existing;
-        }
-        Configuration configuration = rootProject.getConfigurations().maybeCreate(configurationName);
-        File outputDir = new File(rootProject.getBuildDir(), configurationName);
-        rootProject.getDependencies().add(configurationName, dependency);
-        return createExtractTask(rootProject, taskName, configuration, outputDir, executableName);
     }
 
     @InputFiles

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureGeneratorTaskTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureGeneratorTaskTest.groovy
@@ -35,15 +35,19 @@ class ConjureGeneratorTaskTest extends IntegrationSpec {
                 mavenCentral()
                 maven { url 'https://dl.bintray.com/palantir/releases/' }
             }
+            configurations {
+                conjureCompiler
+                conjureJava
+            }
+            dependencies {
+                conjureCompiler 'com.palantir.conjure:conjure:${TestVersions.CONJURE}'
+                conjureJava 'com.palantir.conjure.java:conjure-java:${TestVersions.CONJURE_JAVA}'
+            }
         }
         """.stripIndent()
 
         createFile('api/build.gradle') << """
         apply plugin: 'com.palantir.conjure'
-        dependencies {
-            conjureCompiler 'com.palantir.conjure:conjure:${TestVersions.CONJURE}'
-            conjureJava 'com.palantir.conjure.java:conjure-java:${TestVersions.CONJURE_JAVA}'
-        }
 
         subprojects {
             pluginManager.withPlugin 'java', {

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -163,7 +163,7 @@ class ConjurePluginTest extends IntegrationSpec {
         ExecutionResult result2 = runTasksSuccessfully('check')
 
         then:
-        result.wasExecuted(':api:extractConjureJava')
+        result.wasExecuted(':extractConjureJava')
         result.wasExecuted(':api:api-objects:compileJava')
         result.wasExecuted(':api:compileConjureObjects')
         result.wasExecuted(':api:api-jersey:compileJava')
@@ -175,7 +175,7 @@ class ConjurePluginTest extends IntegrationSpec {
         result.wasExecuted(':api:api-dialogue:compileJava')
         result.wasExecuted(':api:compileConjureDialogue')
 
-        result2.wasUpToDate(':api:extractConjureJava')
+        result2.wasUpToDate(':extractConjureJava')
         result2.wasUpToDate(':api:api-objects:compileJava')
         result2.wasUpToDate(':api:compileConjureObjects')
         result2.wasUpToDate(':api:api-jersey:compileJava')


### PR DESCRIPTION
## Before this PR
Each conjure module would separately extract the conjure compiler and all generators.

## After this PR
==COMMIT_MSG==
Several standard generators are extracted to the project root
==COMMIT_MSG==

## Possible downsides?
`conjureCompiler` and `conjureJava` gradle configurations are not longer created on subprojects, these are only used on the root project. Projects which use these configurations will break unless they move the dependencies to the root project.
This shouldn't impact anyone using GCV where versions are defined globally. It is no longer possible to use different conjure versions across subprojects, but that was never supported using GCV.

