### PR TITLE
Remove hard-coded version from dependency

### DIFF
--- a/changelog/@unreleased/pr-714.v2.yml
+++ b/changelog/@unreleased/pr-714.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Remove hard-coded version from dependency
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/714

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -199,7 +199,7 @@ public final class ConjurePlugin implements Plugin<Project> {
             Task cleanTask = project.getTasks().findByName(TASK_CLEAN);
             cleanTask.dependsOn(project.getTasks().findByName("cleanCompileConjureDialogue"));
             subproj.getDependencies().add("api", findDerivedProject(project, objectsProjectName));
-            subproj.getDependencies().add("api", "com.palantir.dialogue:dialogue-target:1.50.0");
+            subproj.getDependencies().add("api", "com.palantir.dialogue:dialogue-target");
         });
     }
 

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -63,6 +63,7 @@ class ConjurePluginTest extends IntegrationSpec {
                resolutionStrategy {
                    force 'com.palantir.conjure.java:conjure-java:${TestVersions.CONJURE_JAVA}'
                    force 'com.palantir.conjure.java:conjure-lib:${TestVersions.CONJURE_JAVA}'
+                   force 'com.palantir.dialogue:dialogue-target:${TestVersions.CONJURE_JAVA_DIALOG}'
                    force 'com.palantir.conjure.java:conjure-undertow-lib:${TestVersions.CONJURE_JAVA}'
                    force 'com.palantir.conjure:conjure:${TestVersions.CONJURE}'
                    force 'com.palantir.conjure.typescript:conjure-typescript:${TestVersions.CONJURE_TYPESCRIPT}'

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/TestVersions.java
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/TestVersions.java
@@ -21,6 +21,7 @@ public final class TestVersions {
 
     public static final String CONJURE = "4.11.2";
     public static final String CONJURE_JAVA = "5.17.0";
+    public static final String CONJURE_JAVA_DIALOG = "1.50.0";
     public static final String CONJURE_PYTHON = "3.11.6";
     public static final String CONJURE_TYPESCRIPT = "3.8.1";
     public static final String CONJURE_POSTMAN = "0.1.2";


### PR DESCRIPTION
This can cause version conflicts in edge cases for some particular projects

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

