### PR TITLE
remove duplicate code for java project init

### DIFF
--- a/changelog/@unreleased/pr-761.v2.yml
+++ b/changelog/@unreleased/pr-761.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Unified init code, with consumer passed in for the couple lines of customization for each.
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/761


### PR DESCRIPTION
## Before this PR
the 5 java project types had about 98% duplicated code to init them.  I couldn't take it any more.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Unified init code, with consumer passed in for the couple lines of customization for each.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

