### PR TITLE
Add support for optional service dependencies

### DIFF
--- a/changelog/@unreleased/pr-769.v2.yml
+++ b/changelog/@unreleased/pr-769.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Added support for optional service dependencies.
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/769

--- a/gradle-conjure-api/src/main/java/com/palantir/gradle/conjure/api/ServiceDependency.java
+++ b/gradle-conjure-api/src/main/java/com/palantir/gradle/conjure/api/ServiceDependency.java
@@ -37,6 +37,9 @@ public final class ServiceDependency implements Serializable {
     @JsonProperty("recommended-version")
     private String recommendedVersion;
 
+    @JsonProperty("optional")
+    private boolean optional = false;
+
     public String getProductGroup() {
         return productGroup;
     }
@@ -77,6 +80,14 @@ public final class ServiceDependency implements Serializable {
         this.recommendedVersion = recommendedVersion;
     }
 
+    public boolean getOptional() {
+        return optional;
+    }
+
+    public void setOptional(boolean optional) {
+        this.optional = optional;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -90,11 +101,12 @@ public final class ServiceDependency implements Serializable {
                 && Objects.equals(productName, that.productName)
                 && Objects.equals(minimumVersion, that.minimumVersion)
                 && Objects.equals(maximumVersion, that.maximumVersion)
-                && Objects.equals(recommendedVersion, that.recommendedVersion);
+                && Objects.equals(recommendedVersion, that.recommendedVersion)
+                && optional == that.optional;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(productGroup, productName, minimumVersion, maximumVersion, recommendedVersion);
+        return Objects.hash(productGroup, productName, minimumVersion, maximumVersion, recommendedVersion, optional);
     }
 }


### PR DESCRIPTION
## Before this PR
It's currently not possible to specify optional service dependencies. This makes it impossible to have an API
project render multiple optional product dependencies e.g.

## After this PR
An API project can now specify optional service dependencies.
This is useful in the scenario where an API might have several different
implementing services e.g.

