### PR TITLE
Move ConjureProductDependenciesExtension to api package

### DIFF
--- a/changelog/@unreleased/pr-771.v2.yml
+++ b/changelog/@unreleased/pr-771.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Move ConjureProductDependenciesExtension to api package
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/771

--- a/gradle-conjure-api/src/main/java/com/palantir/gradle/conjure/api/ConjureProductDependenciesExtension.java
+++ b/gradle-conjure-api/src/main/java/com/palantir/gradle/conjure/api/ConjureProductDependenciesExtension.java
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 
-package com.palantir.gradle.conjure;
+package com.palantir.gradle.conjure.api;
 
-import com.palantir.gradle.conjure.api.EndpointMinimumVersion;
-import com.palantir.gradle.conjure.api.ServiceDependency;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import java.util.HashSet;
@@ -44,10 +42,6 @@ public class ConjureProductDependenciesExtension {
         this.providerFactory = project.getProviders();
     }
 
-    public final Set<ServiceDependency> getProductDependencies() {
-        return productDependencies;
-    }
-
     public final void serviceDependency(@DelegatesTo(ServiceDependency.class) Closure<ServiceDependency> closure) {
         ServiceDependency serviceDependency = new ServiceDependency();
         closure.setDelegate(serviceDependency);
@@ -61,6 +55,10 @@ public class ConjureProductDependenciesExtension {
             ConfigureUtil.configureUsing(closure).execute(emv);
             return emv;
         }));
+    }
+
+    public final Set<ServiceDependency> getProductDependencies() {
+        return productDependencies;
     }
 
     public final SetProperty<EndpointMinimumVersion> getEndpointVersions() {

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConfigureEndpointMinimumVersionsTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConfigureEndpointMinimumVersionsTask.java
@@ -19,6 +19,7 @@ package com.palantir.gradle.conjure;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import com.palantir.gradle.conjure.api.ConjureProductDependenciesExtension;
 import com.palantir.gradle.conjure.api.EndpointMinimumVersion;
 import com.palantir.logsafe.Preconditions;
 import java.util.List;

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureBasePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureBasePlugin.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.conjure;
 
+import com.palantir.gradle.conjure.api.ConjureProductDependenciesExtension;
 import java.io.File;
 import java.util.Collections;
 import org.gradle.api.Action;

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaServiceDependencies.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaServiceDependencies.java
@@ -17,6 +17,7 @@
 package com.palantir.gradle.conjure;
 
 import com.google.common.collect.Iterables;
+import com.palantir.gradle.conjure.api.ConjureProductDependenciesExtension;
 import com.palantir.gradle.conjure.api.ServiceDependency;
 import com.palantir.gradle.dist.ConfigureProductDependenciesTask;
 import com.palantir.gradle.dist.ProductDependency;

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.palantir.gradle.conjure.api.ConjureExtension;
+import com.palantir.gradle.conjure.api.ConjureProductDependenciesExtension;
 import com.palantir.gradle.conjure.api.GeneratorOptions;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
@@ -17,6 +17,7 @@
 package com.palantir.gradle.conjure
 
 import com.palantir.gradle.dist.RecommendedProductDependencies
+import com.palantir.gradle.conjure.api.ConjureProductDependenciesExtension;
 
 import java.util.jar.Attributes
 import java.util.jar.Manifest


### PR DESCRIPTION
## Before this PR
`ConjureProductDependenciesExtension` was removed from the `.api` package in 87ac7c954bd28d0231b840090cf43723d77d2364, breaking consumers that relied on it.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Move ConjureProductDependenciesExtension to api package
==COMMIT_MSG==
