### PR TITLE
Move ConjureProductDependenciesExtension back to api package

### DIFF
--- a/changelog/@unreleased/pr-772.v2.yml
+++ b/changelog/@unreleased/pr-772.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Move ConjureProductDependenciesExtension back to api package
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/772

--- a/gradle-conjure-api/build.gradle
+++ b/gradle-conjure-api/build.gradle
@@ -18,5 +18,6 @@ apply plugin: 'com.palantir.external-publish-jar'
 
 dependencies {
     compile localGroovy()
+    compile gradleApi()
     compile 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/gradle-conjure-api/src/main/java/com/palantir/gradle/conjure/api/ConjureProductDependenciesExtension.java
+++ b/gradle-conjure-api/src/main/java/com/palantir/gradle/conjure/api/ConjureProductDependenciesExtension.java
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 
-package com.palantir.gradle.conjure;
+package com.palantir.gradle.conjure.api;
 
-import com.palantir.gradle.conjure.api.EndpointMinimumVersion;
-import com.palantir.gradle.conjure.api.ServiceDependency;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import java.util.HashSet;

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConfigureEndpointMinimumVersionsTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConfigureEndpointMinimumVersionsTask.java
@@ -19,6 +19,7 @@ package com.palantir.gradle.conjure;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import com.palantir.gradle.conjure.api.ConjureProductDependenciesExtension;
 import com.palantir.gradle.conjure.api.EndpointMinimumVersion;
 import com.palantir.logsafe.Preconditions;
 import java.util.List;

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureBasePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureBasePlugin.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.conjure;
 
+import com.palantir.gradle.conjure.api.ConjureProductDependenciesExtension;
 import java.io.File;
 import java.util.Collections;
 import org.gradle.api.Action;

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaServiceDependencies.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaServiceDependencies.java
@@ -17,6 +17,7 @@
 package com.palantir.gradle.conjure;
 
 import com.google.common.collect.Iterables;
+import com.palantir.gradle.conjure.api.ConjureProductDependenciesExtension;
 import com.palantir.gradle.conjure.api.ServiceDependency;
 import com.palantir.gradle.dist.ConfigureProductDependenciesTask;
 import com.palantir.gradle.dist.ProductDependency;

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.palantir.gradle.conjure.api.ConjureExtension;
+import com.palantir.gradle.conjure.api.ConjureProductDependenciesExtension;
 import com.palantir.gradle.conjure.api.GeneratorOptions;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.conjure
 
+import com.palantir.gradle.conjure.api.ConjureProductDependenciesExtension
 import com.palantir.gradle.dist.RecommendedProductDependencies
 
 import java.util.jar.Attributes


### PR DESCRIPTION
## Before this PR
In https://github.com/palantir/gradle-conjure/pull/762 the package location of `ConjureProductDependenciesExtension` got changed which was an unintentional break for consumers.

## After this PR
Move `ConjureProductDependenciesExtension` back to the `api` package.

==COMMIT_MSG==
Move ConjureProductDependenciesExtension back to api package
==COMMIT_MSG==

Note that this also adds a compile dependency on the gradle api to the gradle-conjure-api package.