### PR TITLE
Set output directory for compileTypeScript task

### DIFF
--- a/changelog/@unreleased/pr-792.v2.yml
+++ b/changelog/@unreleased/pr-792.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: '`compileTypeScript` now declares its outputs so the task can be avoided
+    if it is up-to-date.'
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/792

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -352,6 +352,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                     task.commandLine(npmCommand, "run-script", "build");
                     task.workingDir(srcDirectory);
                     task.dependsOn(installTypeScriptDependencies);
+                    task.getOutputs().dir(srcDirectory);
                 });
                 Task publishTypeScript = project.getTasks().create("publishTypeScript", Exec.class, task -> {
                     task.setDescription("Runs `npm publish` to publish a TypeScript package "

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePublishTypeScriptTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePublishTypeScriptTest.groovy
@@ -119,14 +119,14 @@ class ConjurePublishTypeScriptTest extends IntegrationSpec {
         file('api/api-typescript/src/index.js').text.contains('export * from "./api";')
     }
 
-    def 'compileConjureTypeScript is up-to-date when run for the second time'() {
+    def 'compileTypeScript is up-to-date when run for the second time'() {
         when:
-        ExecutionResult first = runTasksSuccessfully('compileConjureTypeScript')
-        first.wasExecuted(':api:compileConjureTypeScript')
-        ExecutionResult second = runTasksSuccessfully('compileConjureTypeScript')
+        ExecutionResult first = runTasksSuccessfully('compileTypeScript')
+        first.wasExecuted(':api:compileTypeScript')
+        ExecutionResult second = runTasksSuccessfully('compileTypeScript')
 
         then:
-        second.wasUpToDate(':api:compileConjureTypeScript')
+        second.wasUpToDate(':api:compileTypeScript')
     }
 
     def 'publishes generated code'() {


### PR DESCRIPTION
## Before this PR
`compileTypeScript` is always run because it does not declare outputs.

![Screen Shot 2021-06-09 at 2 52 09 PM](https://user-images.githubusercontent.com/5273164/121434541-54039200-c932-11eb-835c-354dce01e9dc.png)

## After this PR
`compileTypeScript` declares it's outputs and will not be re-run if it is up-to-date.

I've verified this locally. Here the build scans:
First build: https://g.p.b/s/3jidjf6nifcea/timeline
Second build: https://g.p.b/s/bilbi3h7eakpa/timeline