### PR TITLE
Revert optimization that sometimes caused infinite loops in TreeMaps

### DIFF
--- a/changelog/@unreleased/pr-793.v2.yml
+++ b/changelog/@unreleased/pr-793.v2.yml
@@ -1,6 +1,6 @@
 type: fix
 fix:
-  description: Revert a performance optimization for large builds that sometimes reverted
+  description: Revert a performance optimization for large builds that sometimes resulted
     in hangs due to infinite loops in TreeMap#get.
   links:
   - https://github.com/palantir/gradle-conjure/pull/793

--- a/changelog/@unreleased/pr-793.v2.yml
+++ b/changelog/@unreleased/pr-793.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Revert a performance optimization for large builds that sometimes reverted
+    in hangs due to infinite loops in TreeMap#get.
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/793

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureRunnerResource.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureRunnerResource.java
@@ -75,7 +75,7 @@ public abstract class ConjureRunnerResource implements BuildService<Params>, Clo
         void invoke(Project project, String failedTo, List<String> unloggedArgs, List<String> loggedArgs);
     }
 
-    private static ConjureRunner createNewRunner(File executable) throws IOException {
+    static ConjureRunner createNewRunner(File executable) throws IOException {
         Optional<StartScriptInfo> maybeJava = ReverseEngineerJavaStartScript.maybeParseStartScript(executable.toPath());
         if (maybeJava.isPresent()) {
             ReverseEngineerJavaStartScript.StartScriptInfo info = maybeJava.get();

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GradleExecUtils.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GradleExecUtils.java
@@ -25,8 +25,8 @@ final class GradleExecUtils {
 
     static void exec(
             Project project, String failedTo, File executable, List<String> unloggedArgs, List<String> loggedArgs) {
-        try {
-            ConjureRunnerResource.createNewRunner(executable).invoke(project, failedTo, unloggedArgs, loggedArgs);
+        try (ConjureRunnerResource.ConjureRunner runner = ConjureRunnerResource.createNewRunner(executable)) {
+            runner.invoke(project, failedTo, unloggedArgs, loggedArgs);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GradleExecUtils.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GradleExecUtils.java
@@ -16,32 +16,20 @@
 
 package com.palantir.gradle.conjure;
 
-import com.palantir.gradle.conjure.ConjureRunnerResource.Params;
 import java.io.File;
+import java.io.IOException;
 import java.util.List;
-import org.gradle.api.Action;
 import org.gradle.api.Project;
-import org.gradle.api.services.BuildServiceSpec;
 
 final class GradleExecUtils {
 
     static void exec(
             Project project, String failedTo, File executable, List<String> unloggedArgs, List<String> loggedArgs) {
-        project.getGradle()
-                .getSharedServices()
-                .registerIfAbsent(
-                        // Executable name must be the cache key, neither the spec parameters
-                        // nor the class are taken into account for caching.
-                        "conjure-runner-" + executable,
-                        ConjureRunnerResource.class,
-                        new Action<BuildServiceSpec<Params>>() {
-                            @Override
-                            public void execute(BuildServiceSpec<Params> spec) {
-                                spec.getParameters().getExecutable().set(executable);
-                            }
-                        })
-                .get()
-                .invoke(project, failedTo, unloggedArgs, loggedArgs);
+        try {
+            ConjureRunnerResource.createNewRunner(executable).invoke(project, failedTo, unloggedArgs, loggedArgs);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private GradleExecUtils() {}


### PR DESCRIPTION
The BuildServicesRegistry is apparently not thread-safe, so we
need to either move this registration to during Gradle configuration
or use some other caching mechanism (e.g. put a cache object on an
extension of the root project).

I have left ConjureRunnerResource intact with the expectation
that it will be either used or removed in a subsequent fix of the
optimization. This PR is just to quickly get to a state where we
don't run into this problem.

==COMMIT_MSG==
Revert a performance optimization for large builds that sometimes resulted in hangs due to infinite loops in TreeMap#get.
==COMMIT_MSG==