### PR TITLE
Disallow non-generated dirs in main sourcesets

### DIFF
--- a/changelog/@unreleased/pr-818.v2.yml
+++ b/changelog/@unreleased/pr-818.v2.yml
@@ -1,0 +1,20 @@
+type: improvement
+improvement:
+  description: |-
+    Disallow non-generated dirs in main sourcesets
+
+    ## Before this PR
+    The conjure-consumer dependency scanning strategy relies on annotations
+    in Generated Java code to determine minimum service dependencies. This does
+    not work for any non-generated code.
+
+    To prevent unexpected problems, all non-generated code must be excluded
+    from the Conjure generated Javaprojects.
+
+    ## After this PR
+    Gradle will error out whenever it finds a non-generated source directory in any of the Java (e.g. objects, dialogue) generated subprojects
+
+    ## Possible downsides?
+    Users must move non generated code outside of the generated subprojects if they want to continue using gradle-conjure
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/818

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -16,7 +16,6 @@
 
 package com.palantir.gradle.conjure
 
-
 import nebula.test.IntegrationSpec
 import nebula.test.functional.ExecutionResult
 import spock.lang.IgnoreIf
@@ -260,6 +259,19 @@ class ConjurePluginTest extends IntegrationSpec {
         'sub'      | 'api'
         'peer'     | ''
     }
+
+    def 'disallows sourcesets other than src/generated/java'() {
+        setup:
+        createFile('api/api-dialogue/src/main/java/com/palantir/gotham/RandoEndpoint.java')
+
+        when:
+        ExecutionResult result = runTasks(':api-dialogue:compileJava')
+
+        then:
+        Throwable ex = result.getFailure()
+        ex.cause.cause.message.contains("Non-generated source directories not allowed")
+    }
+
 
     def 'compileConjure creates build/conjure for root project'() {
         when:


### PR DESCRIPTION


## Before this PR
The conjure-consumer dependency scanning strategy relies on annotations
in Generated Java code to determine minimum service dependencies. This does
not work for any non-generated code.

To prevent unexpected problems, all non-generated code must be excluded
from the Conjure generated Javaprojects.

## After this PR
Gradle will error out whenever it finds a non-generated source directory in any of the Java (e.g. objects, dialogue) generated subprojects

## Possible downsides?
Users must move non generated code outside of the generated subprojects if they want to continue using gradle-conjure
