### PR TITLE
use the task-config avoidance APIs

### DIFF
--- a/changelog/@unreleased/pr-826.v2.yml
+++ b/changelog/@unreleased/pr-826.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: use the task-config avoidance APIs
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/826

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureBasePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureBasePlugin.java
@@ -129,7 +129,7 @@ public final class ConjureBasePlugin implements Plugin<Project> {
                     });
                 });
 
-        ConjurePlugin.registerClean(project, "cleanCopyConjureSourcesIntoBuild");
+        ConjurePlugin.registerClean(project, copyConjureSourcesTask);
 
         return copyConjureSourcesTask;
     }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureBasePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureBasePlugin.java
@@ -32,7 +32,6 @@ import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Copy;
 import org.gradle.api.tasks.TaskProvider;
-import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.util.GFileUtils;
 
 public final class ConjureBasePlugin implements Plugin<Project> {
@@ -130,9 +129,7 @@ public final class ConjureBasePlugin implements Plugin<Project> {
                     });
                 });
 
-        project.getTasks()
-                .getByName(LifecycleBasePlugin.CLEAN_TASK_NAME)
-                .dependsOn(project.getTasks().findByName("cleanCopyConjureSourcesIntoBuild"));
+        ConjurePlugin.registerClean(project, "cleanCopyConjureSourcesIntoBuild");
 
         return copyConjureSourcesTask;
     }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -34,7 +34,6 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.plugins.JavaBasePlugin;
@@ -113,7 +112,7 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
         project.getDependencies().add("api", "com.palantir.conjure.java:conjure-lib");
         project.getDependencies().add("compileOnly", ConjurePlugin.ANNOTATION_API);
 
-        Task generateGitIgnore = ConjurePlugin.createWriteGitignoreTask(
+        TaskProvider<WriteGitignoreTask> generateGitIgnore = ConjurePlugin.createWriteGitignoreTask(
                 project, "gitignoreConjure", project.getProjectDir(), ConjurePlugin.JAVA_GITIGNORE_CONTENTS);
 
         Provider<File> conjureIrFile = extractConjureIr.map(
@@ -143,7 +142,7 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
                 });
 
         project.getTasks().named("compileJava").configure(compileJava -> compileJava.dependsOn(generateJava));
-        ConjurePlugin.applyDependencyForIdeTasks(project, generateJava.get());
+        ConjurePlugin.applyDependencyForIdeTasks(project, generateJava);
     }
 
     /**

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
@@ -111,15 +111,14 @@ public final class ConjureLocalPlugin implements Plugin<Project> {
                     task.setOutputDirectory(subproj.file(ConjurePlugin.JAVA_GENERATED_SOURCE_DIRNAME));
 
                     generateConjure.dependsOn(task);
-                    subproj.getTasks().getByName("compileJava").dependsOn(task);
 
                     task.dependsOn(gitignoreConjureJava);
                     task.dependsOn(extractJavaTask);
 
-                    Task cleanTask = project.getTasks().findByName(ConjurePlugin.TASK_CLEAN);
-                    cleanTask.dependsOn(project.getTasks().findByName("cleanGenerateJava"));
                     subproj.getDependencies().add("api", subproj);
                 });
+        subproj.getTasks().named("compileJava").configure(t -> t.dependsOn(generateJava));
+        ConjurePlugin.registerClean(project, "cleanGenerateJava");
         ConjurePlugin.applyDependencyForIdeTasks(subproj, generateJava);
     }
 

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
@@ -118,7 +118,7 @@ public final class ConjureLocalPlugin implements Plugin<Project> {
         generateConjure.configure(t -> t.dependsOn(generateJava));
 
         subproj.getTasks().named("compileJava").configure(t -> t.dependsOn(generateJava));
-        ConjurePlugin.registerClean(project, "cleanGenerateJava");
+        ConjurePlugin.registerClean(project, generateJava);
         ConjurePlugin.applyDependencyForIdeTasks(subproj, generateJava);
     }
 

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -372,8 +372,9 @@ public final class ConjurePlugin implements Plugin<Project> {
                             task.dependsOn(compileConjureTypeScript);
                             task.dependsOn(compileTypeScript);
                         });
-                subproj.afterEvaluate(
-                        _p -> subproj.getTasks().maybeCreate("publish").dependsOn(publishTypeScript));
+                subproj.getPluginManager().withPlugin("maven-publish", _packagingPlugin -> {
+                    subproj.getTasks().named("publish").configure(t -> t.dependsOn(publishTypeScript));
+                });
             });
             TaskProvider<Task> cleanCompileConjureTypeScript =
                     project.getTasks().named("cleanCompileConjureTypeScript");

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePublishPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePublishPlugin.java
@@ -19,9 +19,7 @@ package com.palantir.gradle.conjure;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
 import org.gradle.api.UnknownDomainObjectException;
-import org.gradle.api.UnknownTaskException;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin;
@@ -49,10 +47,11 @@ public final class ConjurePublishPlugin implements Plugin<Project> {
                 publications.create(
                         "conjure",
                         MavenPublication.class,
-                        mavenPublication -> mavenPublication.artifact(finalCompileIr.flatMap(CompileIrTask::getOutputIrFile), mavenArtifact -> {
-                            mavenArtifact.builtBy(finalCompileIr);
-                            mavenArtifact.setExtension("conjure.json");
-                        }));
+                        mavenPublication -> mavenPublication.artifact(
+                                finalCompileIr.flatMap(CompileIrTask::getOutputIrFile), mavenArtifact -> {
+                                    mavenArtifact.builtBy(finalCompileIr);
+                                    mavenArtifact.setExtension("conjure.json");
+                                }));
             });
         });
     }


### PR DESCRIPTION
## Before this PR
Nearly all tasks in the plugin are  created eagerly

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
use the task-config avoidance APIs
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

