### PR TITLE
move conjure generator tasks to task-avoidance APIs

### DIFF
--- a/changelog/@unreleased/pr-828.v2.yml
+++ b/changelog/@unreleased/pr-828.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: use the task-config avoidance APIs and newer Property APIs
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/828

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileConjurePythonTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/CompileConjurePythonTask.java
@@ -28,7 +28,7 @@ import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
 
 @CacheableTask
-public class CompileConjurePythonTask extends ConjureGeneratorTask {
+public abstract class CompileConjurePythonTask extends ConjureGeneratorTask {
 
     @Override
     protected final Map<String, Supplier<Object>> requiredOptions(File _file) {

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureBasePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureBasePlugin.java
@@ -74,13 +74,13 @@ public final class ConjureBasePlugin implements Plugin<Project> {
             Project project,
             ConjureProductDependenciesExtension pdepsExtension,
             TaskProvider<Copy> copyConjureSourcesTask) {
-        ExtractExecutableTask extractCompilerTask = ExtractConjurePlugin.applyConjureCompiler(project);
+        TaskProvider<ExtractExecutableTask> extractCompilerTask = ExtractConjurePlugin.applyConjureCompiler(project);
 
         Provider<Directory> irDir = project.getLayout().getBuildDirectory().dir("conjure-ir");
 
         project.getTasks().register("rawIr", CompileIrTask.class, rawIr -> {
-            rawIr.setInputDirectory(copyConjureSourcesTask.map(Copy::getDestinationDir)::get);
-            rawIr.setExecutableDir(extractCompilerTask::getOutputDirectory);
+            rawIr.getInputDirectory().set(project.getLayout().dir(copyConjureSourcesTask.map(Copy::getDestinationDir)));
+            rawIr.getExecutableDir().set(extractCompilerTask.flatMap(ExtractExecutableTask::getOutputDirectory));
             rawIr.getOutputIrFile().set(irDir.map(dir -> dir.file("rawIr.conjure.json")));
             rawIr.dependsOn(copyConjureSourcesTask);
             rawIr.dependsOn(extractCompilerTask);
@@ -90,8 +90,10 @@ public final class ConjureBasePlugin implements Plugin<Project> {
             compileIr.setDescription("Converts your Conjure YML files into a single portable JSON file in IR format.");
             compileIr.setGroup(ConjureBasePlugin.TASK_GROUP);
 
-            compileIr.setInputDirectory(copyConjureSourcesTask.map(Copy::getDestinationDir)::get);
-            compileIr.setExecutableDir(extractCompilerTask::getOutputDirectory);
+            compileIr
+                    .getInputDirectory()
+                    .set(project.getLayout().dir(copyConjureSourcesTask.map(Copy::getDestinationDir)));
+            compileIr.getExecutableDir().set(extractCompilerTask.flatMap(ExtractExecutableTask::getOutputDirectory));
             compileIr.getOutputIrFile().set(irDir.map(dir -> dir.file(project.getName() + ".conjure.json")));
             compileIr.getProductDependencies().set(project.provider(pdepsExtension::getProductDependencies));
             compileIr.dependsOn(copyConjureSourcesTask);

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -62,7 +62,7 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
             task.into(project.getLayout().getBuildDirectory().dir("conjure-ir"));
         });
 
-        ExtractExecutableTask extractJavaTask = ExtractConjurePlugin.applyConjureJava(project);
+        TaskProvider<ExtractExecutableTask> extractJavaTask = ExtractConjurePlugin.applyConjureJava(project);
 
         setupSubprojects(project, extension, extractJavaTask, extractConjureIr, conjureIrConfiguration);
     }
@@ -70,7 +70,7 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
     private static void setupSubprojects(
             Project project,
             ConjureExtension extension,
-            ExtractExecutableTask extractJavaTask,
+            TaskProvider<ExtractExecutableTask> extractJavaTask,
             TaskProvider<Copy> extractConjureIr,
             Configuration conjureIrConfiguration) {
 
@@ -105,7 +105,7 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
     private static void createGenerateTask(
             Project project,
             ConjureExtension extension,
-            ExtractExecutableTask extractJavaTask,
+            TaskProvider<ExtractExecutableTask> extractJavaTask,
             TaskProvider<Copy> extractConjureIr) {
         ConjurePlugin.addGeneratedToMainSourceSet(project);
 
@@ -127,8 +127,8 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
                     task.setSource(conjureIrFile);
                     task.getExecutablePath()
                             .set(project.getLayout()
-                                    .file(project.provider(
-                                            () -> OsUtils.appendDotBatIfWindows(extractJavaTask.getExecutable()))));
+                                    .file(extractJavaTask.map(t -> OsUtils.appendDotBatIfWindows(
+                                            t.getExecutable().getAsFile().get()))));
                     task.getOptions().set(project.provider(() -> {
                         Map<String, Object> properties =
                                 new HashMap<>(extension.getJava().getProperties());

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalGenerateGenericTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalGenerateGenericTask.java
@@ -24,7 +24,7 @@ import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class ConjureLocalGenerateGenericTask extends ConjureLocalGenerateTask {
+public abstract class ConjureLocalGenerateGenericTask extends ConjureLocalGenerateTask {
 
     private static final Pattern PATTERN =
             Pattern.compile("^(.*)-([0-9]+\\.[0-9]+\\.[0-9]+(?:-rc[0-9]+)?(?:-g[a-f0-9]+)?)(?:.conjure)?.json$");

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalGenerateTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalGenerateTask.java
@@ -20,12 +20,14 @@ import java.io.File;
 import org.gradle.api.tasks.CacheableTask;
 
 @CacheableTask
-public class ConjureLocalGenerateTask extends ConjureGeneratorTask {
+public abstract class ConjureLocalGenerateTask extends ConjureGeneratorTask {
 
     @Override
     protected final File outputDirectoryFor(File file) {
         // Strip extension and version
-        return new File(
-                getOutputDirectory(), file.getName().substring(0, file.getName().lastIndexOf("-")));
+        return getOutputDirectory()
+                .dir(file.getName().substring(0, file.getName().lastIndexOf("-")))
+                .get()
+                .getAsFile();
     }
 }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ExtractConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ExtractConjurePlugin.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.tasks.TaskProvider;
 
 abstract class ExtractConjurePlugin implements Plugin<Project> {
 
@@ -57,16 +58,16 @@ abstract class ExtractConjurePlugin implements Plugin<Project> {
         ExtractExecutableTask.createExtractTask(project, taskName, configuration, outputDir, executableName);
     }
 
-    static ExtractExecutableTask applyConjureCompiler(Project project) {
+    static TaskProvider<ExtractExecutableTask> applyConjureCompiler(Project project) {
         return applyAndGet(project, ExtractConjureCompilerPlugin.class, ExtractConjureCompilerPlugin.TASK_NAME);
     }
 
-    static ExtractExecutableTask applyConjureJava(Project project) {
+    static TaskProvider<ExtractExecutableTask> applyConjureJava(Project project) {
         return applyAndGet(project, ExtractConjureJavaPlugin.class, ExtractConjureJavaPlugin.TASK_NAME);
     }
 
-    static ExtractExecutableTask applyConjureTypeScript(Project project) {
-        ExtractExecutableTask result =
+    static TaskProvider<ExtractExecutableTask> applyConjureTypeScript(Project project) {
+        TaskProvider<ExtractExecutableTask> result =
                 applyAndGet(project, ExtractConjureTypeScriptPlugin.class, ExtractConjureTypeScriptPlugin.TASK_NAME);
         // Preserve the conjureTypescript configuration so publishing works
         if (!Objects.equals(project, project.getRootProject())) {
@@ -76,15 +77,15 @@ abstract class ExtractConjurePlugin implements Plugin<Project> {
         return result;
     }
 
-    static ExtractExecutableTask applyConjurePython(Project project) {
+    static TaskProvider<ExtractExecutableTask> applyConjurePython(Project project) {
         return applyAndGet(project, ExtractConjurePythonPlugin.class, ExtractConjurePythonPlugin.TASK_NAME);
     }
 
-    private static ExtractExecutableTask applyAndGet(
+    private static TaskProvider<ExtractExecutableTask> applyAndGet(
             Project provided, Class<? extends Plugin<? extends Project>> plugin, String name) {
         Project project = provided.getRootProject();
         project.getPluginManager().apply(plugin);
-        return (ExtractExecutableTask) project.getTasks().getByName(name);
+        return project.getTasks().named(name, ExtractExecutableTask.class);
     }
 
     static final class ExtractConjureCompilerPlugin extends ExtractConjurePlugin {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
move conjure generator tasks to task-avoidance APIs
==COMMIT_MSG==

## Possible downsides?
Removing the various "set" methods on tasks could break existing projects that customize tasks. We can either role the major API or (better) mark them as deprecated instead of deleting them. I just deleted initially to see how clean I could get things. 

