### PR TITLE
Make max versino optional instead of default x.x.x

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -23,3 +23,20 @@ acceptedBreaks:
         \ com.palantir.gradle.conjure.api.ConjureProductDependenciesExtension::getEndpointVersions()"
       justification: "Revert changes made in 5.13.0"
   "5.15.0": {}
+  "5.16.0":
+    com.palantir.gradle.conjure:gradle-conjure-api:
+    - code: "java.class.defaultSerializationChanged"
+      old: "class com.palantir.gradle.conjure.api.EndpointVersionBound"
+      new: "class com.palantir.gradle.conjure.api.EndpointVersionBound"
+      justification: "Set max version to optional instead of default value of x.x.x.\
+        \ Not currently used."
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter void com.palantir.gradle.conjure.api.EndpointVersionBound::setMaxVersion(===java.lang.String===)"
+      new: "parameter void com.palantir.gradle.conjure.api.EndpointVersionBound::setMaxVersion(===java.util.Optional<java.lang.String>===)"
+      justification: "Set max version to optional instead of default value of x.x.x.\
+        \ Not currently used."
+    - code: "java.method.returnTypeChanged"
+      old: "method java.lang.String com.palantir.gradle.conjure.api.EndpointVersionBound::getMaxVersion()"
+      new: "method java.util.Optional<java.lang.String> com.palantir.gradle.conjure.api.EndpointVersionBound::getMaxVersion()"
+      justification: "Set max version to optional instead of default value of x.x.x.\
+        \ Not currently used."

--- a/changelog/@unreleased/pr878.v2.yml
+++ b/changelog/@unreleased/pr878.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Max version in EndpointVersionBound is Optional instead of defaulting to "x.x.x"
+  links:
+    - https://github.com/palantir/gradle-conjure/pull/878

--- a/gradle-conjure-api/src/main/java/com/palantir/gradle/conjure/api/EndpointVersionBound.java
+++ b/gradle-conjure-api/src/main/java/com/palantir/gradle/conjure/api/EndpointVersionBound.java
@@ -19,6 +19,7 @@ package com.palantir.gradle.conjure.api;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.Optional;
 
 public final class EndpointVersionBound implements Serializable {
 
@@ -32,7 +33,7 @@ public final class EndpointVersionBound implements Serializable {
     private String minVersion;
 
     @JsonProperty("max-version")
-    private String maxVersion = "x.x.x";
+    private Optional<String> maxVersion;
 
     public String getHttpPath() {
         return httpPath;
@@ -58,15 +59,15 @@ public final class EndpointVersionBound implements Serializable {
         this.minVersion = minVersion;
     }
 
-    public String getMaxVersion() {
+    public Optional<String> getMaxVersion() {
         if (maxVersion != null) {
             return maxVersion;
         } else {
-            return "x.x.x";
+            return Optional.empty();
         }
     }
 
-    public void setMaxVersion(String maxVersion) {
+    public void setMaxVersion(Optional<String> maxVersion) {
         this.maxVersion = maxVersion;
     }
 

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
@@ -407,7 +407,7 @@ class ConjureServiceDependencyTest extends IntegrationSpec {
         //check to make sure we didn't stomp over the recommended-product-dependencies
         recommendedDeps.contains('"recommended-product-dependencies"')
         def endpointVersions = attributes.getValue(ConjureProductDependenciesExtension.ENDPOINT_VERSIONS_MANIFEST_KEY)
-        endpointVersions == '{"endpoint-version-bounds":[{"http-path":"/post","http-method":"POST","min-version":"0.1.0","max-version":"x.x.x"}]}'
+        endpointVersions == '{"endpoint-version-bounds":[{"http-path":"/post","http-method":"POST","min-version":"0.1.0"}]}'
     }
 
     Attributes getAttributes(File jarFile) {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Max version should be optional instead of default max value of x.x.x.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Max version in EndpointVersionBound is Optional instead of defaulting to x.x.x
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

