### PR TITLE
Revert optional max version change.

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -40,3 +40,13 @@ acceptedBreaks:
       new: "method java.util.Optional<java.lang.String> com.palantir.gradle.conjure.api.EndpointVersionBound::getMaxVersion()"
       justification: "Set max version to optional instead of default value of x.x.x.\
         \ Not currently used."
+  "5.17.0":
+    com.palantir.gradle.conjure:gradle-conjure-api:
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter void com.palantir.gradle.conjure.api.EndpointVersionBound::setMaxVersion(===java.util.Optional<java.lang.String>===)"
+      new: "parameter void com.palantir.gradle.conjure.api.EndpointVersionBound::setMaxVersion(===java.lang.String===)"
+      justification: "Reverting a change."
+    - code: "java.method.returnTypeChanged"
+      old: "method java.util.Optional<java.lang.String> com.palantir.gradle.conjure.api.EndpointVersionBound::getMaxVersion()"
+      new: "method java.lang.String com.palantir.gradle.conjure.api.EndpointVersionBound::getMaxVersion()"
+      justification: "Reverting a change."

--- a/changelog/@unreleased/pr879.v2.yml
+++ b/changelog/@unreleased/pr879.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+improvement:
+  description: revert optional max version change
+  links:
+    - https://github.com/palantir/gradle-conjure/pull/879

--- a/gradle-conjure-api/src/main/java/com/palantir/gradle/conjure/api/EndpointVersionBound.java
+++ b/gradle-conjure-api/src/main/java/com/palantir/gradle/conjure/api/EndpointVersionBound.java
@@ -19,7 +19,6 @@ package com.palantir.gradle.conjure.api;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.util.Objects;
-import java.util.Optional;
 
 public final class EndpointVersionBound implements Serializable {
 
@@ -33,7 +32,7 @@ public final class EndpointVersionBound implements Serializable {
     private String minVersion;
 
     @JsonProperty("max-version")
-    private Optional<String> maxVersion;
+    private String maxVersion;
 
     public String getHttpPath() {
         return httpPath;
@@ -59,15 +58,15 @@ public final class EndpointVersionBound implements Serializable {
         this.minVersion = minVersion;
     }
 
-    public Optional<String> getMaxVersion() {
+    public String getMaxVersion() {
         if (maxVersion != null) {
             return maxVersion;
         } else {
-            return Optional.empty();
+            return "x.x.x";
         }
     }
 
-    public void setMaxVersion(Optional<String> maxVersion) {
+    public void setMaxVersion(String maxVersion) {
         this.maxVersion = maxVersion;
     }
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
While the previous API change didn't have any consumers, the Optional is behaving much differently.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
While the previous API change didn't have any consumers, the Optional is behaving much differently.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

