### PR TITLE
Make max version nullable by adding JsonInclude NON_NULL.

### DIFF
--- a/changelog/@unreleased/pr883.v2.yml
+++ b/changelog/@unreleased/pr883.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Allow empty max versions without default values.
+  links:
+    - https://github.com/palantir/gradle-conjure/pull/883

--- a/gradle-conjure-api/src/main/java/com/palantir/gradle/conjure/api/EndpointVersionBound.java
+++ b/gradle-conjure-api/src/main/java/com/palantir/gradle/conjure/api/EndpointVersionBound.java
@@ -16,9 +16,12 @@
 
 package com.palantir.gradle.conjure.api;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.Optional;
 
 public final class EndpointVersionBound implements Serializable {
 
@@ -31,6 +34,7 @@ public final class EndpointVersionBound implements Serializable {
     @JsonProperty("min-version")
     private String minVersion;
 
+    @JsonInclude(Include.NON_ABSENT)
     @JsonProperty("max-version")
     private String maxVersion;
 
@@ -58,12 +62,8 @@ public final class EndpointVersionBound implements Serializable {
         this.minVersion = minVersion;
     }
 
-    public String getMaxVersion() {
-        if (maxVersion != null) {
-            return maxVersion;
-        } else {
-            return "x.x.x";
-        }
+    public Optional<String> getMaxVersion() {
+        return Optional.ofNullable(maxVersion);
     }
 
     public void setMaxVersion(String maxVersion) {

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConfigureEndpointVersionBoundsTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConfigureEndpointVersionBoundsTask.java
@@ -18,6 +18,7 @@ package com.palantir.gradle.conjure;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.gradle.conjure.api.ConjureProductDependenciesExtension;
 import com.palantir.gradle.conjure.api.EndpointVersionBound;
@@ -68,16 +69,17 @@ public class ConfigureEndpointVersionBoundsTask extends DefaultTask {
         org.gradle.api.plugins.JavaPluginConvention javaConvention =
                 project.getConvention().getPlugin(org.gradle.api.plugins.JavaPluginConvention.class);
         return javaConvention.manifest(manifest -> {
-            String minVersionsString;
+            String versionBoundsString;
             try {
                 EndpointVersionBounds evbs =
                         EndpointVersionBounds.builder().versionBounds(versions).build();
-                minVersionsString = new ObjectMapper().writeValueAsString(evbs);
+                versionBoundsString =
+                        new ObjectMapper().registerModule(new Jdk8Module()).writeValueAsString(evbs);
             } catch (JsonProcessingException e) {
-                throw new GradleException("Couldn't serialize endpoint minimum versions as string", e);
+                throw new GradleException("Couldn't serialize endpoint version bounds as string", e);
             }
             manifest.attributes(ImmutableMap.of(
-                    ConjureProductDependenciesExtension.ENDPOINT_VERSIONS_MANIFEST_KEY, minVersionsString));
+                    ConjureProductDependenciesExtension.ENDPOINT_VERSIONS_MANIFEST_KEY, versionBoundsString));
         });
     }
 }

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
@@ -380,7 +380,7 @@ class ConjureServiceDependencyTest extends IntegrationSpec {
         endpointVersions == '{"endpoint-version-bounds":[{"http-path":"/post","http-method":"POST","min-version":"0.1.0","max-version":"1.2.0"}]}'
     }
 
-    def "default maximum endpoint information written if missing"() {
+    def "nullable endpoint maximum version bound"() {
         setup:
         file('api/build.gradle') << '''
         serviceDependencies {
@@ -408,7 +408,7 @@ class ConjureServiceDependencyTest extends IntegrationSpec {
         //check to make sure we didn't stomp over the recommended-product-dependencies
         recommendedDeps.contains('"recommended-product-dependencies"')
         def endpointVersions = attributes.getValue(ConjureProductDependenciesExtension.ENDPOINT_VERSIONS_MANIFEST_KEY)
-        endpointVersions == '{"endpoint-version-bounds":[{"http-path":"/post","http-method":"POST","min-version":"0.1.0","max-version":"x.x.x"}]}'
+        endpointVersions == '{"endpoint-version-bounds":[{"http-path":"/post","http-method":"POST","min-version":"0.1.0"}]}'
     }
 
     Attributes getAttributes(File jarFile) {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Previously null/empty max versions defaulted to x.x.x which we don't want.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Allow empty max versions without default values.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

