### PR TITLE
ignore warnings from generated code in eclipse

### DIFF
--- a/changelog/@unreleased/pr-951.v2.yml
+++ b/changelog/@unreleased/pr-951.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: ignore warnings from generated code in eclipse
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/951

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -34,6 +34,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -612,18 +613,21 @@ public final class ConjurePlugin implements Plugin<Project> {
                     eclipse.jdt(jdt -> {
                         jdt.file(file -> {
                             file.withProperties(properties -> {
-                                properties.put(
-                                        "org.eclipse.jdt.core.compiler.problem.missingOverrideAnnotation", "ignore");
-                                properties.put(
-                                        "org.eclipse.jdt.core.compiler.problem.missingOverrideAnnotationForInterfaceMethodImplementation",
-                                        "disabled");
-                                properties.put("org.eclipse.jdt.core.compiler.problem.unusedPrivateMember", "ignore");
+                                configureEclipseJdt(properties);
                             });
                         });
                     });
                 }
             });
         });
+    }
+
+    private static void configureEclipseJdt(Properties properties) {
+        properties.put("org.eclipse.jdt.core.compiler.problem.missingOverrideAnnotation", "ignore");
+        properties.put(
+                "org.eclipse.jdt.core.compiler.problem.missingOverrideAnnotationForInterfaceMethodImplementation",
+                "disabled");
+        properties.put("org.eclipse.jdt.core.compiler.problem.unusedPrivateMember", "ignore");
     }
 
     private static <T> Set<T> mutableSetWithExtraEntry(Set<T> set, T extraItem) {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Eclipse warns about generated code.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
ignore warnings from generated code in eclipse
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
Strict improvement. The only problem that I know of is gradle-baseline applies the eclipse configuration in afterEvaluate, which I use here, but there is no guarantee that gradle-baseline's code will be applied before this one.

A possible alternate solution is to add `@SuppressWarnings("all")` in the conjure generated code.
