### PR TITLE
compileConjure* depends on compileIr

### DIFF
--- a/changelog/@unreleased/pr-980.v2.yml
+++ b/changelog/@unreleased/pr-980.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: compileConjure* depends on compileIr to allow caching and gradle 8
+    compatibility
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/980

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -227,7 +227,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                                 "gitignoreConjure" + upperSuffix,
                                 subproj.getProjectDir(),
                                 JAVA_GITIGNORE_CONTENTS));
-                        task.dependsOn(extractJavaTask);
+                        task.dependsOn(extractJavaTask, compileIrTask);
                     });
             subproj.getTasks().named("compileJava").configure(t -> t.dependsOn(conjureGeneratorTask));
             applyDependencyForIdeTasks(subproj, conjureGeneratorTask);


### PR DESCRIPTION
==COMMIT_MSG==
compileConjure* depends on compileIr
==COMMIT_MSG==

Ideally we'd have test coverage for this sort of thing.
