### PR TITLE
Allow a single optional service dependency

### DIFF
--- a/changelog/@unreleased/pr-982.v2.yml
+++ b/changelog/@unreleased/pr-982.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Allow a single optional service dependency
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/982

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaServiceDependencies.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaServiceDependencies.java
@@ -16,13 +16,11 @@
 
 package com.palantir.gradle.conjure;
 
-import com.google.common.collect.Iterables;
 import com.palantir.gradle.conjure.api.ConjureProductDependenciesExtension;
 import com.palantir.gradle.conjure.api.ServiceDependency;
 import com.palantir.gradle.dist.ProductDependency;
 import com.palantir.gradle.dist.RecommendedProductDependenciesExtension;
 import com.palantir.gradle.dist.RecommendedProductDependenciesPlugin;
-import com.palantir.logsafe.Preconditions;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.gradle.api.Project;
@@ -64,13 +62,6 @@ final class ConjureJavaServiceDependencies {
     }
 
     private static Set<ProductDependency> convertDependencies(Set<ServiceDependency> serviceDependencies) {
-        // See https://github.com/palantir/gradle-conjure/pull/769
-        // We currently don't know of any valid use-case in which it would be correct to declare a single, optional
-        // service dependency, so the intent of this is to protect against accidental misconfiguration e.g.
-        Preconditions.checkArgument(
-                serviceDependencies.size() != 1
-                        || !Iterables.getOnlyElement(serviceDependencies).getOptional(),
-                "a single optional service dependency is not supported");
         return serviceDependencies.stream()
                 .map(serviceDependency -> new ProductDependency(
                         serviceDependency.getProductGroup(),

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
@@ -259,23 +259,6 @@ class ConjureServiceDependencyTest extends IntegrationSpec {
                 ']}'
     }
 
-    def "fails on a single optional dependency"() {
-        file('api/build.gradle') << '''
-        serviceDependencies {
-            serviceDependency {
-                productGroup = "com.palantir.conjure"
-                productName = "conjure"
-                minimumVersion = "1.2.0"
-                recommendedVersion = "1.2.0"
-                maximumVersion = "2.x.x"
-                optional = true
-            }
-        }
-        '''.stripIndent()
-        expect:
-        runTasksWithFailure(':api:api-jersey:Jar')
-    }
-
     def "fails on absent fields"() {
         file('api/build.gradle') << '''
         serviceDependencies {


### PR DESCRIPTION
The use case I have for this is a custom spark datasource, which I am attempting to roll out to all Spark clients. My custom Spark datasource has a service dependency on my service, which is not installed globally. My service is also solely responsible for creating the datasets that use this spark datasource type; without my service installed, there is no reason for spark clients to ever need to make api calls to my service.

My spark datasource is the second spark datasource that has run into this problem, so I know this isn't a one-off issue.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

