### PR TITLE
Add explicit task dependencies on compile ir task

### DIFF
--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -227,7 +227,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                                 "gitignoreConjure" + upperSuffix,
                                 subproj.getProjectDir(),
                                 JAVA_GITIGNORE_CONTENTS));
-                        task.dependsOn(extractJavaTask);
+                        task.dependsOn(extractJavaTask, compileIrTask);
                     });
             subproj.getTasks().named("compileJava").configure(t -> t.dependsOn(conjureGeneratorTask));
             applyDependencyForIdeTasks(subproj, conjureGeneratorTask);
@@ -353,8 +353,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                             task.setOptions(options);
                             task.dependsOn(createWriteGitignoreTask(
                                     subproj, "gitignoreConjureTypeScript", subproj.getProjectDir(), "/src/\n"));
-                            task.dependsOn(extractConjureTypeScriptTask);
-                            task.dependsOn(productDependencyTask);
+                            task.dependsOn(extractConjureTypeScriptTask, productDependencyTask, compileIrTask);
                         });
                 compileConjure.configure(t -> t.dependsOn(compileConjureTypeScript));
                 registerClean(project, compileConjureTypeScript);
@@ -437,7 +436,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                             task.setOptions(options);
                             task.dependsOn(createWriteGitignoreTask(
                                     subproj, "gitignoreConjurePython", subproj.getProjectDir(), "/python/\n"));
-                            task.dependsOn(extractConjurePythonTask);
+                            task.dependsOn(extractConjurePythonTask, compileIrTask);
                         });
                 compileConjure.configure(t -> t.dependsOn(compileConjurePython));
                 project.getTasks().register("buildWheel", Exec.class, task -> {
@@ -532,7 +531,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                                 .set(extractConjureGeneratorTask.flatMap(ExtractExecutableTask::getExecutable));
                         task.setOptions(() -> getGenericOptions.apply(conjureLanguage));
                         task.getOutputDirectory().set(subproject.file("src"));
-                        task.dependsOn(extractConjureGeneratorTask);
+                        task.dependsOn(extractConjureGeneratorTask, compileIrTask);
                     });
             compileConjure.configure(t -> t.dependsOn(conjureLocalGenerateTask));
         });


### PR DESCRIPTION
## Before this PR

For most generate conjure tasks, we consume the output of the `compileIr` task through `task.setSource(compileIrTask);` without adding an additional explicit task dependency ([example](https://github.com/palantir/gradle-conjure/blob/42494eed36e551d0a5eeb3c48fa527c86aee460d/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java#L223)).

In previous versions, Gradle would add the task dependency for you. However in newer Gradle versions this is discouraged, resulting in warnings and in some cases, Gradle proactively disabling caching for the consuming compile conjure tasks.

## After this PR

Add the explicit task dependencies from the compile conjure to compileIr tasks.

==COMMIT_MSG==
Add explicit task dependencies on compile ir task
==COMMIT_MSG==