### PR TITLE
Feature: Add task that generates .npmrc based on the upstream repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,21 @@ For conjure-typescript, this information is passed as an extra flag, `--productD
 
 For conjure-java, this information is directly embedded into the Jar for the `-jersey` and `-retrofit` projects.  It is stored as a manifest property, `Sls-Recommended-Product-Dependencies`, which can be detected by [sls-packaging](https://github.com/palantir/sls-packaging).
 
+### Typescript
+
+typescript project generate .npmrc for publishing to configured repository. You
+can specify custom repo in gradle.properties
+```
+npmRepositoryUri = <my-repository-url>
+```
+
+and configure credentials for publishing using (ideally picking the values up
+from environment variables)
+
+```gradle
+tasks.generateNpmRc.username = <publish-username>
+tasks.generateNpmRc.password = <publish-password>
+```
 
 ## com.palantir.conjure-publish
 To enable publishing of your API definition for external consumption, add the `com.palantir.conjure-publish` which applies `com.palantir.conjure` and also creates a new `"conjure"` publication.

--- a/README.md
+++ b/README.md
@@ -84,13 +84,7 @@ can specify custom repo in gradle.properties
 npmRepositoryUri = <my-repository-url>
 ```
 
-and configure credentials for publishing using (ideally picking the values up
-from environment variables)
-
-```gradle
-tasks.generateNpmRc.username = <publish-username>
-tasks.generateNpmRc.password = <publish-password>
-```
+and configure credentials for publishing using environment variables ARTIFACTORY_USERNAME and ARTIFACTORY_PASSWORD.
 
 ## com.palantir.conjure-publish
 To enable publishing of your API definition for external consumption, add the `com.palantir.conjure-publish` which applies `com.palantir.conjure` and also creates a new `"conjure"` publication.

--- a/README.md
+++ b/README.md
@@ -79,12 +79,12 @@ For conjure-java, this information is directly embedded into the Jar for the `-j
 ### Typescript
 
 typescript project generate .npmrc for publishing to configured repository. You
-can specify custom repo in gradle.properties
+can specify custom registry in gradle.properties
 ```
-npmRepositoryUri = <my-repository-url>
+npmRegistryUri = <my-registry-url>
 ```
 
-and configure credentials for publishing using environment variables ARTIFACTORY_USERNAME and ARTIFACTORY_PASSWORD.
+and configure credentials for publishing using environment variables REGISTRY_USERNAME and REGISTRY_PASSWORD.
 
 ## com.palantir.conjure-publish
 To enable publishing of your API definition for external consumption, add the `com.palantir.conjure-publish` which applies `com.palantir.conjure` and also creates a new `"conjure"` publication.

--- a/changelog/@unreleased/pr-1025.v2.yml
+++ b/changelog/@unreleased/pr-1025.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Add task that generates .npmrc for configured repository and username
+    and password
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/1025

--- a/gradle-conjure/build.gradle
+++ b/gradle-conjure/build.gradle
@@ -101,3 +101,9 @@ tasks.withType(JavaCompile).configureEach {
         check('Slf4jLogsafeArgs', CheckSeverity.OFF)
     }
 }
+
+
+test {
+    environment "ARTIFACTORY_PASSWORD", "pass"
+    environment "ARTIFACTORY_USERNAME", "user"
+}

--- a/gradle-conjure/build.gradle
+++ b/gradle-conjure/build.gradle
@@ -104,6 +104,6 @@ tasks.withType(JavaCompile).configureEach {
 
 
 test {
-    environment "ARTIFACTORY_PASSWORD", "pass"
-    environment "ARTIFACTORY_USERNAME", "user"
+    environment "REGISTRY_USERNAME", "user"
+    environment "REGISTRY_PASSWORD", "pass"
 }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -387,6 +387,22 @@ public final class ConjurePlugin implements Plugin<Project> {
                             task.dependsOn(compileConjureTypeScript);
                             task.dependsOn(compileTypeScript);
                         });
+                TaskProvider<GenerateNpmRcTask> generateNpmRc = project.getTasks()
+                        .register("generateNpmRc", GenerateNpmRcTask.class, task -> {
+                            task.setDescription(
+                                    "Generates .npmrc file suitable for publishing to configured upstream repo");
+                            task.setGroup(TASK_GROUP);
+                            task.dependsOn(compileConjureTypeScript);
+                            task.mustRunAfter(compileTypeScript);
+                            task.getPackageName()
+                                    .set(compileConjureTypeScript.flatMap(
+                                            CompileConjureTypeScriptTask::getPackageName));
+                            task.getOutputFile().fileProvider(publishTypeScript.map(t -> t.getWorkingDir()
+                                    .toPath()
+                                    .resolve(".npmrc")
+                                    .toFile()));
+                        });
+                publishTypeScript.configure(t -> t.dependsOn(generateNpmRc));
                 linkPublish(subproj, publishTypeScript);
             });
         }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GenerateNpmRcTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GenerateNpmRcTask.java
@@ -45,24 +45,14 @@ public class GenerateNpmRcTask extends DefaultTask {
     private static final JsonMapper MAPPER = ObjectMappers.newClientJsonMapper();
 
     private static final String NPM_REGISTRY_URI_PROPERTY = "npmRegistryUri";
+    private static final String ARTIFACTORY_USERNAME_NAME = "ARTIFACTORY_USERNAME";
+    private static final String ARTIFACTORY_PASSWORD_NAME = "ARTIFACTORY_PASSWORD";
     private final RegularFileProperty outputFile = getProject().getObjects().fileProperty();
-    private final Property<String> username = getProject().getObjects().property(String.class);
-    private final Property<String> password = getProject().getObjects().property(String.class);
     private final Property<String> packageName = getProject().getObjects().property(String.class);
 
     @OutputFile
     public final RegularFileProperty getOutputFile() {
         return this.outputFile;
-    }
-
-    @Input
-    public final Property<String> getUsername() {
-        return username;
-    }
-
-    @Input
-    public final Property<String> getPassword() {
-        return password;
     }
 
     @Input
@@ -87,7 +77,8 @@ public class GenerateNpmRcTask extends DefaultTask {
 
         String registryUri = getNpmRegistryUri();
         String strippedUri = registryUri.startsWith("https://") ? registryUri.substring(8) : registryUri.substring(7);
-        NpmTokenResponse npmTokenResponse = tokenFromCreds(registryUri, username.get(), password.get());
+        NpmTokenResponse npmTokenResponse = tokenFromCreds(
+                registryUri, System.getenv(ARTIFACTORY_USERNAME_NAME), System.getenv(ARTIFACTORY_PASSWORD_NAME));
 
         String scopeRegistry = scope.map(s -> s + ":").orElse("");
         String npmRcContents = String.format(

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GenerateNpmRcTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GenerateNpmRcTask.java
@@ -112,7 +112,7 @@ public class GenerateNpmRcTask extends DefaultTask {
                                 .PUT(BodyPublishers.ofString(
                                         MAPPER.writeValueAsString(ImmutableNpmTokenRequest.of(username, password))))
                                 .build(),
-                        responseInfo -> BodySubscribers.mapping(BodySubscribers.ofByteArray(), inputStream -> {
+                        _responseInfo -> BodySubscribers.mapping(BodySubscribers.ofByteArray(), inputStream -> {
                             try {
                                 return MAPPER.readValue(inputStream, NpmTokenResponse.class);
                             } catch (IOException e) {

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GenerateNpmRcTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GenerateNpmRcTask.java
@@ -1,5 +1,17 @@
 /*
- * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.&#10;&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;    http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License.
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.palantir.gradle.conjure;

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GenerateNpmRcTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GenerateNpmRcTask.java
@@ -1,0 +1,136 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.&#10;&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;    http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License.
+ */
+
+package com.palantir.gradle.conjure;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.google.common.net.HttpHeaders;
+import com.palantir.conjure.java.serialization.ObjectMappers;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodySubscribers;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Optional;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value.Parameter;
+
+public class GenerateNpmRcTask extends DefaultTask {
+    private static final JsonMapper MAPPER = ObjectMappers.newClientJsonMapper();
+
+    private static final String NPM_REGISTRY_URI_PROPERTY = "npmRegistryUri";
+    private final RegularFileProperty outputFile = getProject().getObjects().fileProperty();
+    private final Property<String> username = getProject().getObjects().property(String.class);
+    private final Property<String> password = getProject().getObjects().property(String.class);
+    private final Property<String> packageName = getProject().getObjects().property(String.class);
+
+    @OutputFile
+    public final RegularFileProperty getOutputFile() {
+        return this.outputFile;
+    }
+
+    @Input
+    public final Property<String> getUsername() {
+        return username;
+    }
+
+    @Input
+    public final Property<String> getPassword() {
+        return password;
+    }
+
+    @Input
+    public final Property<String> getPackageName() {
+        return packageName;
+    }
+
+    // mainly for tests and should not be included in the generator options
+    private String getNpmRegistryUri() {
+        String userRegistry = getProject().hasProperty(NPM_REGISTRY_URI_PROPERTY)
+                ? getProject().property(NPM_REGISTRY_URI_PROPERTY).toString()
+                : "https://registry.npmjs.org";
+        return userRegistry.endsWith("/") ? userRegistry.substring(0, userRegistry.length() - 1) : userRegistry;
+    }
+
+    @TaskAction
+    public final void createNpmrc() throws IOException, InterruptedException {
+        int slashIndex = packageName.get().indexOf("/");
+        Optional<String> scope = packageName.get().startsWith("@") && slashIndex != -1
+                ? Optional.of(packageName.get().substring(1, slashIndex))
+                : Optional.empty();
+
+        String registryUri = getNpmRegistryUri();
+        String strippedUri = registryUri.startsWith("https://") ? registryUri.substring(8) : registryUri.substring(7);
+        NpmTokenResponse npmTokenResponse = tokenFromCreds(registryUri, username.get(), password.get());
+
+        String scopeRegistry = scope.map(s -> s + ":").orElse("");
+        String npmRcContents = String.format(
+                "%sregistry=%s\n//%s/:_authToken=%s",
+                scopeRegistry, registryUri, strippedUri, npmTokenResponse.token());
+
+        try {
+            Files.writeString(outputFile.getAsFile().get().toPath(), npmRcContents, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static NpmTokenResponse tokenFromCreds(String registryUri, String username, String password)
+            throws IOException, InterruptedException {
+        HttpResponse<NpmTokenResponse> response = HttpClient.newHttpClient()
+                .send(
+                        HttpRequest.newBuilder()
+                                .header(HttpHeaders.ACCEPT, "application/json")
+                                .header(HttpHeaders.CONTENT_TYPE, "application/json")
+                                .uri(URI.create(String.format("%s/-/user/org.couchdb.user:%s", registryUri, username)))
+                                .PUT(BodyPublishers.ofString(
+                                        MAPPER.writeValueAsString(ImmutableNpmTokenRequest.of(username, password))))
+                                .build(),
+                        responseInfo -> BodySubscribers.mapping(BodySubscribers.ofByteArray(), inputStream -> {
+                            try {
+                                return MAPPER.readValue(inputStream, NpmTokenResponse.class);
+                            } catch (IOException e) {
+                                throw new RuntimeException(e);
+                            }
+                        }));
+        if (response.statusCode() >= 400) {
+            throw new RuntimeException("Call to registry failed: " + response.statusCode());
+        }
+
+        return response.body();
+    }
+
+    @Immutable
+    @JsonSerialize(as = ImmutableNpmTokenRequest.class)
+    @JsonDeserialize(as = ImmutableNpmTokenRequest.class)
+    interface NpmTokenRequest {
+        @Parameter
+        String name();
+
+        @Parameter
+        String password();
+    }
+
+    @Immutable
+    @JsonSerialize(as = ImmutableNpmTokenResponse.class)
+    @JsonDeserialize(as = ImmutableNpmTokenResponse.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    interface NpmTokenResponse {
+        @Parameter
+        String token();
+    }
+}

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GenerateNpmRcTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GenerateNpmRcTask.java
@@ -45,8 +45,8 @@ public class GenerateNpmRcTask extends DefaultTask {
     private static final JsonMapper MAPPER = ObjectMappers.newClientJsonMapper();
 
     private static final String NPM_REGISTRY_URI_PROPERTY = "npmRegistryUri";
-    private static final String ARTIFACTORY_USERNAME_NAME = "ARTIFACTORY_USERNAME";
-    private static final String ARTIFACTORY_PASSWORD_NAME = "ARTIFACTORY_PASSWORD";
+    private static final String REGISTRY_USERNAME = "REGISTRY_USERNAME";
+    private static final String REGISTRY_PASSWORD = "REGISTRY_PASSWORD";
     private final RegularFileProperty outputFile = getProject().getObjects().fileProperty();
     private final Property<String> packageName = getProject().getObjects().property(String.class);
 
@@ -76,8 +76,8 @@ public class GenerateNpmRcTask extends DefaultTask {
 
         String registryUri = getNpmRegistryUri();
         String strippedUri = registryUri.startsWith("https://") ? registryUri.substring(8) : registryUri.substring(7);
-        String username = System.getenv(ARTIFACTORY_USERNAME_NAME);
-        String password = System.getenv(ARTIFACTORY_PASSWORD_NAME);
+        String username = System.getenv(REGISTRY_USERNAME);
+        String password = System.getenv(REGISTRY_PASSWORD);
 
         String tokenString = username != null && password != null
                 ? String.format(

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePublishTypeScriptTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePublishTypeScriptTest.groovy
@@ -147,6 +147,7 @@ class ConjurePublishTypeScriptTest extends IntegrationSpec {
 
         then:
         file('api/api-typescript/src/.npmrc').text.contains('_authToken=atoken')
+        file('api/api-typescript/src/.npmrc').text.contains('registry=http://localhost:8888')
         result.wasExecuted('api:generateNpmRc')
         result.wasExecuted('api:compileTypeScript')
         result.wasExecuted('api:publishTypeScript')

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePublishTypeScriptTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePublishTypeScriptTest.groovy
@@ -79,7 +79,6 @@ class ConjurePublishTypeScriptTest extends IntegrationSpec {
                   object: StringExample
                 returns: StringExample
         '''.stripIndent()
-        file("gradle.properties") << "org.gradle.daemon=false"
     }
 
     def 'installs dependencies'() {
@@ -133,27 +132,24 @@ class ConjurePublishTypeScriptTest extends IntegrationSpec {
         given:
         MockWebServer server = new MockWebServer()
         server.start(8888)
+        // generateNpmRc will make request for token
+        server.enqueue(new MockResponse().setBody("{\"token\": \"atoken\"}"))
         // npm publish makes two requests to the registry
         server.enqueue(new MockResponse())
         server.enqueue(new MockResponse())
         file('api/build.gradle').text = """
         apply plugin: 'com.palantir.conjure'
-        publishTypeScript.doFirst {
-            file('api-typescript/src/.npmrc') << '''
-            registry=http://localhost:8888
-            //localhost:8888/:_password=password
-            //localhost:8888/:username=test-publish
-            //localhost:8888/:email=test@palantir.com
-            //localhost:8888/:always-auth=true
-            '''.stripIndent()
-        }
+        tasks.generateNpmRc.username = "test-publish"
+        tasks.generateNpmRc.password = "password"
         """.stripIndent()
+        file("gradle.properties") << "npmRegistryUri=http://localhost:8888"
 
         when:
         ExecutionResult result = runTasksSuccessfully('publish')
 
         then:
-        file('api/api-typescript/src/.npmrc').text.contains('registry=')
+        file('api/api-typescript/src/.npmrc').text.contains('_authToken=atoken')
+        result.wasExecuted('api:generateNpmRc')
         result.wasExecuted('api:publishTypeScript')
         result.wasExecuted('api:compileTypeScript')
 

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePublishTypeScriptTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePublishTypeScriptTest.groovy
@@ -139,8 +139,6 @@ class ConjurePublishTypeScriptTest extends IntegrationSpec {
         server.enqueue(new MockResponse())
         file('api/build.gradle').text = """
         apply plugin: 'com.palantir.conjure'
-        tasks.generateNpmRc.username = "test-publish"
-        tasks.generateNpmRc.password = "password"
         """.stripIndent()
         file("gradle.properties") << "npmRegistryUri=http://localhost:8888"
 

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePublishTypeScriptTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePublishTypeScriptTest.groovy
@@ -148,8 +148,8 @@ class ConjurePublishTypeScriptTest extends IntegrationSpec {
         then:
         file('api/api-typescript/src/.npmrc').text.contains('_authToken=atoken')
         result.wasExecuted('api:generateNpmRc')
-        result.wasExecuted('api:publishTypeScript')
         result.wasExecuted('api:compileTypeScript')
+        result.wasExecuted('api:publishTypeScript')
 
         cleanup:
         server.shutdown()


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add task that generates .npmrc for configured repository and username and password
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

