### PR TITLE
Improvement: Bring back generateNpmrc with full configurability

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ For conjure-java, this information is directly embedded into the Jar for the `-j
 Typescript projects provide generateNpmrc task that generates .npmrc for publishing to configured repository. Credentials are configured using properties `username` and `password` and you can provide custom registry with `registryUri` parameter 
 ```groovy
 generateNpmrc.registryUri = "https://my-custom-registry.com"
+generateNpmrc.token = "<registry-token>" // System.env.<TOKEN>
+```
+Alternatively you can use username and password and the plugin will perform the login operation to obtain a publish token for you.
+```groovy
 generateNpmrc.username = "<username>" // System.env.<USERNAME>
 generateNpmrc.password = "<password>" // System.env.<PASSWORD>
 ```

--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ For conjure-typescript, this information is passed as an extra flag, `--productD
 
 For conjure-java, this information is directly embedded into the Jar for the `-jersey` and `-retrofit` projects.  It is stored as a manifest property, `Sls-Recommended-Product-Dependencies`, which can be detected by [sls-packaging](https://github.com/palantir/sls-packaging).
 
+### Typescript
+
+typescript project generate .npmrc for publishing to configured repository. You
+can specify custom registry in gradle.properties
+```
+npmRegistryUri = <my-registry-url>
+```
+
+and configure credentials for publishing using environment variables REGISTRY_USERNAME and REGISTRY_PASSWORD.
 
 ## com.palantir.conjure-publish
 To enable publishing of your API definition for external consumption, add the `com.palantir.conjure-publish` which applies `com.palantir.conjure` and also creates a new `"conjure"` publication.

--- a/README.md
+++ b/README.md
@@ -78,13 +78,12 @@ For conjure-java, this information is directly embedded into the Jar for the `-j
 
 ### Typescript
 
-typescript project generate .npmrc for publishing to configured repository. You
-can specify custom registry in gradle.properties
+Typescript projects provide generateNpmrc task that generates .npmrc for publishing to configured repository. Credentials are configured using properties `username` and `password` and you can provide custom registry with `registryUri` parameter 
+```groovy
+generateNpmrc.registryUri = "https://my-custom-registry.com"
+generateNpmrc.username = "<username>" // System.env.<USERNAME>
+generateNpmrc.password = "<password>" // System.env.<PASSWORD>
 ```
-npmRegistryUri = <my-registry-url>
-```
-
-and configure credentials for publishing using environment variables REGISTRY_USERNAME and REGISTRY_PASSWORD.
 
 ## com.palantir.conjure-publish
 To enable publishing of your API definition for external consumption, add the `com.palantir.conjure-publish` which applies `com.palantir.conjure` and also creates a new `"conjure"` publication.

--- a/changelog/@unreleased/pr-1053.v2.yml
+++ b/changelog/@unreleased/pr-1053.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Provide unopinionated task for generating npmrc that lets users publish
+    conjure clients to their npm repos
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/1053

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -386,6 +386,25 @@ public final class ConjurePlugin implements Plugin<Project> {
                             task.dependsOn(compileConjureTypeScript);
                             task.dependsOn(compileTypeScript);
                         });
+                TaskProvider<GenerateNpmrcTask> generateNpmrc = project.getTasks()
+                        .register("generateNpmrc", GenerateNpmrcTask.class, task -> {
+                            task.setDescription(
+                                    "Generates .npmrc file suitable for publishing to configured upstream repo");
+                            task.setGroup(TASK_GROUP);
+                            task.dependsOn(compileConjureTypeScript);
+                            task.mustRunAfter(compileTypeScript);
+                            task.getPackageName()
+                                    .set(project.provider(options::get)
+                                            .map(opts ->
+                                                    opts.has("packageName") ? (String) opts.get("packageName") : null)
+                                            .orElse(compileConjureTypeScript.flatMap(
+                                                    CompileConjureTypeScriptTask::getPackageName)));
+                            task.getOutputFile().fileProvider(publishTypeScript.map(t -> t.getWorkingDir()
+                                    .toPath()
+                                    .resolve(".npmrc")
+                                    .toFile()));
+                        });
+                publishTypeScript.configure(t -> t.dependsOn(generateNpmrc));
                 linkPublish(subproj, publishTypeScript);
             });
         }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GenerateNpmrcTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GenerateNpmrcTask.java
@@ -94,7 +94,7 @@ public class GenerateNpmrcTask extends DefaultTask {
 
     @TaskAction
     public final void createNpmrc() throws IOException, InterruptedException {
-        if (getToken().isPresent() ^ getPassword().isPresent()) {
+        if (getToken().isPresent() && getPassword().isPresent()) {
             throw new GradleException("Either username and password or token must be specified but not both");
         }
         int slashIndex = packageName.get().indexOf("/");

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GenerateNpmrcTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GenerateNpmrcTask.java
@@ -1,0 +1,158 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.conjure;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.google.common.net.HttpHeaders;
+import com.palantir.conjure.java.serialization.ObjectMappers;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodySubscribers;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Optional;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value.Parameter;
+
+public class GenerateNpmrcTask extends DefaultTask {
+    private static final JsonMapper MAPPER = ObjectMappers.newClientJsonMapper();
+
+    private final RegularFileProperty outputFile = getProject().getObjects().fileProperty();
+    private final Property<String> packageName = getProject().getObjects().property(String.class);
+    private final Property<String> npmRegistryUri =
+            getProject().getObjects().property(String.class).convention("https://registry.npmjs.org");
+    private final Property<String> registryUsername = getProject().getObjects().property(String.class);
+    private final Property<String> registryPassword = getProject().getObjects().property(String.class);
+
+    @OutputFile
+    public final RegularFileProperty getOutputFile() {
+        return this.outputFile;
+    }
+
+    @Input
+    public final Property<String> getPackageName() {
+        return packageName;
+    }
+
+    @Input
+    public final Property<String> npmRegistryUri() {
+        return npmRegistryUri;
+    }
+
+    @Input
+    public final Property<String> registryUsername() {
+        return registryUsername;
+    }
+
+    @Input
+    public final Property<String> registryPassword() {
+        return registryPassword;
+    }
+
+    private String getNpmRegistryUri() {
+        return npmRegistryUri.get().endsWith("/")
+                ? npmRegistryUri.get().substring(0, npmRegistryUri.get().length() - 1)
+                : npmRegistryUri.get();
+    }
+
+    @TaskAction
+    public final void createNpmrc() throws IOException, InterruptedException {
+        int slashIndex = packageName.get().indexOf("/");
+        Optional<String> scope = packageName.get().startsWith("@") && slashIndex != -1
+                ? Optional.of(packageName.get().substring(1, slashIndex))
+                : Optional.empty();
+
+        String registryUri = getNpmRegistryUri();
+        String strippedUri = registryUri.startsWith("https://") ? registryUri.substring(8) : registryUri.substring(7);
+        String username = registryUsername.getOrNull();
+        String password = registryPassword.getOrNull();
+
+        String tokenString = username != null && password != null
+                ? String.format(
+                        "\n//%s/:_authToken=%s",
+                        strippedUri,
+                        tokenFromCreds(registryUri, username, password).token())
+                : "";
+
+        String scopeRegistry = scope.map(s -> "@" + s + ":").orElse("");
+        String npmRcContents = scopeRegistry + "registry=" + registryUri + "/" + tokenString;
+
+        try {
+            Files.writeString(outputFile.getAsFile().get().toPath(), npmRcContents, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static NpmTokenResponse tokenFromCreds(String registryUri, String username, String password)
+            throws IOException, InterruptedException {
+        HttpResponse<NpmTokenResponse> response = HttpClient.newHttpClient()
+                .send(
+                        HttpRequest.newBuilder()
+                                .header(HttpHeaders.ACCEPT, "application/json")
+                                .header(HttpHeaders.CONTENT_TYPE, "application/json")
+                                .uri(URI.create(String.format("%s/-/user/org.couchdb.user:%s", registryUri, username)))
+                                .PUT(BodyPublishers.ofString(
+                                        MAPPER.writeValueAsString(ImmutableNpmTokenRequest.of(username, password))))
+                                .build(),
+                        _responseInfo -> BodySubscribers.mapping(BodySubscribers.ofByteArray(), inputStream -> {
+                            try {
+                                return MAPPER.readValue(inputStream, NpmTokenResponse.class);
+                            } catch (IOException e) {
+                                throw new RuntimeException(e);
+                            }
+                        }));
+        if (response.statusCode() >= 400) {
+            throw new RuntimeException("Call to registry failed: " + response.statusCode());
+        }
+
+        return response.body();
+    }
+
+    @Immutable
+    @JsonSerialize(as = ImmutableNpmTokenRequest.class)
+    @JsonDeserialize(as = ImmutableNpmTokenRequest.class)
+    interface NpmTokenRequest {
+        @Parameter
+        String name();
+
+        @Parameter
+        String password();
+    }
+
+    @Immutable
+    @JsonSerialize(as = ImmutableNpmTokenResponse.class)
+    @JsonDeserialize(as = ImmutableNpmTokenResponse.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    interface NpmTokenResponse {
+        @Parameter
+        String token();
+    }
+}

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GenerateNpmrcTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GenerateNpmrcTask.java
@@ -67,12 +67,12 @@ public class GenerateNpmrcTask extends DefaultTask {
     }
 
     @Input
-    public final Property<String> getRegistryUsername() {
+    public final Property<String> getUsername() {
         return registryUsername;
     }
 
     @Input
-    public final Property<String> getRegistryPassword() {
+    public final Property<String> getPassword() {
         return registryPassword;
     }
 

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GenerateNpmrcTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GenerateNpmrcTask.java
@@ -62,21 +62,21 @@ public class GenerateNpmrcTask extends DefaultTask {
     }
 
     @Input
-    public final Property<String> npmRegistryUri() {
+    public final Property<String> getNpmRegistryUri() {
         return npmRegistryUri;
     }
 
     @Input
-    public final Property<String> registryUsername() {
+    public final Property<String> getRegistryUsername() {
         return registryUsername;
     }
 
     @Input
-    public final Property<String> registryPassword() {
+    public final Property<String> getRegistryPassword() {
         return registryPassword;
     }
 
-    private String getNpmRegistryUri() {
+    private String normalizedRegistryUri() {
         return npmRegistryUri.get().endsWith("/")
                 ? npmRegistryUri.get().substring(0, npmRegistryUri.get().length() - 1)
                 : npmRegistryUri.get();
@@ -89,7 +89,7 @@ public class GenerateNpmrcTask extends DefaultTask {
                 ? Optional.of(packageName.get().substring(1, slashIndex))
                 : Optional.empty();
 
-        String registryUri = getNpmRegistryUri();
+        String registryUri = normalizedRegistryUri();
         String strippedUri = registryUri.startsWith("https://") ? registryUri.substring(8) : registryUri.substring(7);
         String username = registryUsername.getOrNull();
         String password = registryPassword.getOrNull();

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePublishTypeScriptTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePublishTypeScriptTest.groovy
@@ -79,7 +79,6 @@ class ConjurePublishTypeScriptTest extends IntegrationSpec {
                   object: StringExample
                 returns: StringExample
         '''.stripIndent()
-        file("gradle.properties") << "org.gradle.daemon=false"
     }
 
     def 'installs dependencies'() {
@@ -133,29 +132,65 @@ class ConjurePublishTypeScriptTest extends IntegrationSpec {
         given:
         MockWebServer server = new MockWebServer()
         server.start(8888)
+        // generateNpmrc will make request for token
+        server.enqueue(new MockResponse().setBody("{\"token\": \"atoken\"}"))
         // npm publish makes two requests to the registry
         server.enqueue(new MockResponse())
         server.enqueue(new MockResponse())
         file('api/build.gradle').text = """
         apply plugin: 'com.palantir.conjure'
-        publishTypeScript.doFirst {
-            file('api-typescript/src/.npmrc') << '''
-            registry=http://localhost:8888
-            //localhost:8888/:_password=password
-            //localhost:8888/:username=test-publish
-            //localhost:8888/:email=test@palantir.com
-            //localhost:8888/:always-auth=true
-            '''.stripIndent()
-        }
+
+        generateNpmrc.registryUri = "http://localhost:8888"
+        generateNpmrc.username = "user"
+        generateNpmrc.password = "pass"
         """.stripIndent()
 
         when:
         ExecutionResult result = runTasksSuccessfully('publish')
 
         then:
-        file('api/api-typescript/src/.npmrc').text.contains('registry=')
-        result.wasExecuted('api:publishTypeScript')
+        file('api/api-typescript/src/.npmrc').text.contains('registry=http://localhost:8888/')
+        file('api/api-typescript/src/.npmrc').text.contains('//localhost:8888/:_authToken=atoken')
+        result.wasExecuted('api:generateNpmrc')
         result.wasExecuted('api:compileTypeScript')
+        result.wasExecuted('api:publishTypeScript')
+
+        cleanup:
+        server.shutdown()
+    }
+
+    def 'publishes generated code with scope'() {
+        given:
+        MockWebServer server = new MockWebServer()
+        server.start(8888)
+        // generateNpmrc will make request for token
+        server.enqueue(new MockResponse().setBody("{\"token\": \"atoken\"}"))
+        // npm publish makes two requests to the registry
+        server.enqueue(new MockResponse())
+        server.enqueue(new MockResponse())
+        file('api/build.gradle').text = """
+        apply plugin: 'com.palantir.conjure'
+        
+        conjure {
+            typescript {
+                packageName = "@test/api"
+            }
+        }
+
+        generateNpmrc.registryUri = "http://localhost:8888"
+        generateNpmrc.username = "user"
+        generateNpmrc.password = "pass"
+        """.stripIndent()
+
+        when:
+        ExecutionResult result = runTasksSuccessfully('publish')
+
+        then:
+        file('api/api-typescript/src/.npmrc').text.contains('@test:registry=http://localhost:8888/')
+        file('api/api-typescript/src/.npmrc').text.contains('//localhost:8888/:_authToken=atoken')
+        result.wasExecuted('api:generateNpmrc')
+        result.wasExecuted('api:compileTypeScript')
+        result.wasExecuted('api:publishTypeScript')
 
         cleanup:
         server.shutdown()


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Provide unopinionated task for generating npmrc that lets users publish conjure clients to their npm repos
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

