### PR TITLE
gradle task configuration avoidance

### DIFF
--- a/changelog/@unreleased/pr-1066.v2.yml
+++ b/changelog/@unreleased/pr-1066.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Avoid creating and configuring gradle tasks
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/1066

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -117,10 +117,13 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
 
         Provider<File> conjureIrFile = extractConjureIr.map(
                 irTask -> new File(irTask.getDestinationDir(), project.getName() + ".conjure.json"));
-        project.getTasks().named("configureProductDependencies", ConfigureProductDependenciesTask.class, task -> {
-            task.setProductDependencies(conjureIrFile.map(ConjureJavaLocalCodegenPlugin::extractProductDependencies));
-            task.dependsOn(extractConjureIr);
-        });
+        project.getTasks()
+                .named("configureProductDependencies", ConfigureProductDependenciesTask.class)
+                .configure(task -> {
+                    task.setProductDependencies(
+                            conjureIrFile.map(ConjureJavaLocalCodegenPlugin::extractProductDependencies));
+                    task.dependsOn(extractConjureIr);
+                });
 
         TaskProvider<ConjureJavaLocalGeneratorTask> generateJava = project.getTasks()
                 .register("generateConjure", ConjureJavaLocalGeneratorTask.class, task -> {

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -310,7 +310,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                 return;
             }
 
-            proj.getTasks().withType(checkUnusedDependenciesTask, task -> {
+            proj.getTasks().withType(checkUnusedDependenciesTask).configureEach(task -> {
                 try {
                     Method ignoreMethod = task.getClass().getMethod("ignore", String.class, String.class);
                     List<String> conjureJavaLibComponents = Splitter.on(':').splitToList(CONJURE_JAVA_LIB_DEP);
@@ -591,9 +591,10 @@ public final class ConjurePlugin implements Plugin<Project> {
                     module.getGeneratedSourceDirs(), project.file(JAVA_GENERATED_SOURCE_DIRNAME)));
         });
         project.getPlugins().withType(EclipsePlugin.class, _plugin -> {
-            Task task = project.getTasks().findByName("eclipseClasspath");
-            if (task != null) {
-                task.dependsOn(compileConjure);
+            try {
+                project.getTasks().named("eclipseClasspath").configure(t -> t.dependsOn(compileConjure));
+            } catch (UnknownDomainObjectException e) {
+                // eclipseClasspath is not always registered
             }
         });
     }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -45,7 +45,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.UnknownDomainObjectException;
+import org.gradle.api.UnknownTaskException;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.file.FileCollection;
@@ -402,7 +402,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                 TaskProvider<Task> publishProvider;
                 try {
                     publishProvider = p.getTasks().named("publish");
-                } catch (UnknownDomainObjectException e) {
+                } catch (UnknownTaskException e) {
                     p.getLogger().debug("Manually creating publish task", e);
                     publishProvider = p.getTasks().register("publish");
                 }
@@ -577,7 +577,7 @@ public final class ConjurePlugin implements Plugin<Project> {
             // safe way to check for existence with the task avoidance APIs
             try {
                 project.getTasks().named("ideaModule").configure(t -> t.dependsOn(compileConjure));
-            } catch (UnknownDomainObjectException e) {
+            } catch (UnknownTaskException e) {
                 project.getLogger().debug("Project does not have ideaModule task.", e);
             }
 
@@ -593,7 +593,7 @@ public final class ConjurePlugin implements Plugin<Project> {
         project.getPlugins().withType(EclipsePlugin.class, _plugin -> {
             try {
                 project.getTasks().named("eclipseClasspath").configure(t -> t.dependsOn(compileConjure));
-            } catch (UnknownDomainObjectException e) {
+            } catch (UnknownTaskException e) {
                 // eclipseClasspath is not always registered
             }
         });


### PR DESCRIPTION
## Before this PR
We are unnecessarily creating and configuring tasks during gradle configuration. See https://docs.gradle.org/current/userguide/task_configuration_avoidance.html for more details.

## After this PR
==COMMIT_MSG==
Avoid creating and configuring gradle tasks
==COMMIT_MSG==

## Possible downsides?
None.

