### PR TITLE
Don't log npm token response on serde error

### DIFF
--- a/changelog/@unreleased/pr-1077.v2.yml
+++ b/changelog/@unreleased/pr-1077.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Don't log npm token response on serde error
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/1077


### PR DESCRIPTION
## Before this PR
FLUP on https://github.com/palantir/gradle-conjure/pull/1053.

## After this PR

The jackson exception message might contain the raw response which can possibly contain sensitive data. E.g. if the registry decides to change their response wire-format, we would log the response including the received publishing token.

==COMMIT_MSG==
Don't log npm token response on serde error
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

