### PR TITLE
Prefer Javax versions instead of the Jakarta Versions

### DIFF
--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -110,7 +110,6 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
         ConjurePlugin.addGeneratedToMainSourceSet(project);
 
         project.getDependencies().add("api", "com.palantir.conjure.java:conjure-lib");
-        project.getDependencies().add("compileOnly", ConjurePlugin.ANNOTATION_API);
 
         TaskProvider<WriteGitignoreTask> generateGitIgnore = ConjurePlugin.createWriteGitignoreTask(
                 project, "gitignoreConjure", project.getProjectDir(), ConjurePlugin.JAVA_GITIGNORE_CONTENTS);

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -289,7 +289,7 @@ public final class ConjurePlugin implements Plugin<Project> {
     }
 
     private static void setupJerseyProject(Project project) {
-        project.getDependencies().add("api", "javax.ws.rs:javax.ws.rs-api");
+        project.getDependencies().add("api", "javax.ws.rs:javax.ws.rs-api:2.1.1");
         project.getDependencies().add("compileOnly", ANNOTATION_API);
     }
 
@@ -567,7 +567,7 @@ public final class ConjurePlugin implements Plugin<Project> {
             return Maps.filterKeys(project.getChildProjects(), childProjectName -> {
                 return childProjectName.startsWith(projectName)
                         && !FIRST_CLASS_GENERATOR_PROJECT_NAMES.contains(
-                                extractSubprojectLanguage(projectName, childProjectName));
+                        extractSubprojectLanguage(projectName, childProjectName));
             });
         } else if (project.hasProperty(GENERIC_GENERATOR_LANGUAGE_NAMES_PROPERTY)) {
             String names = (String) project.getProperties().get(GENERIC_GENERATOR_LANGUAGE_NAMES_PROPERTY);

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -93,7 +93,7 @@ public final class ConjurePlugin implements Plugin<Project> {
 
     static final String CONJURE_GENERATOR_DEP_PREFIX = "conjure-";
     /** Make the old Java8 @Generated annotation available even when compiling with Java9+. */
-    static final String ANNOTATION_API = "jakarta.annotation:jakarta.annotation-api:1.3.5";
+    static final String ANNOTATION_API = "javax.annotation:javax.annotation-api:1.3.2";
 
     /** Tells plugin to look for derived projects at same level as the api project rather than as child projects. */
     static final String USE_FLAT_PROJECT_STRUCTURE_PROPERTY = "com.palantir.conjure.use_flat_project_structure";
@@ -289,7 +289,7 @@ public final class ConjurePlugin implements Plugin<Project> {
     }
 
     private static void setupJerseyProject(Project project) {
-        project.getDependencies().add("api", "jakarta.ws.rs:jakarta.ws.rs-api");
+        project.getDependencies().add("api", "javax.ws.rs:javax.ws.rs-api");
         project.getDependencies().add("compileOnly", ANNOTATION_API);
     }
 
@@ -567,7 +567,7 @@ public final class ConjurePlugin implements Plugin<Project> {
             return Maps.filterKeys(project.getChildProjects(), childProjectName -> {
                 return childProjectName.startsWith(projectName)
                         && !FIRST_CLASS_GENERATOR_PROJECT_NAMES.contains(
-                                extractSubprojectLanguage(projectName, childProjectName));
+                        extractSubprojectLanguage(projectName, childProjectName));
             });
         } else if (project.hasProperty(GENERIC_GENERATOR_LANGUAGE_NAMES_PROPERTY)) {
             String names = (String) project.getProperties().get(GENERIC_GENERATOR_LANGUAGE_NAMES_PROPERTY);

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -289,6 +289,8 @@ public final class ConjurePlugin implements Plugin<Project> {
     }
 
     private static void setupJerseyProject(Project project) {
+        // version is included explicitly to ensure it doesn't have to be pinned
+        // javax version is chosen to avoid conflicts with jakarta EE9 libraries
         project.getDependencies().add("api", "javax.ws.rs:javax.ws.rs-api:2.1.1");
         project.getDependencies().add("compileOnly", ANNOTATION_API);
     }
@@ -567,7 +569,7 @@ public final class ConjurePlugin implements Plugin<Project> {
             return Maps.filterKeys(project.getChildProjects(), childProjectName -> {
                 return childProjectName.startsWith(projectName)
                         && !FIRST_CLASS_GENERATOR_PROJECT_NAMES.contains(
-                        extractSubprojectLanguage(projectName, childProjectName));
+                                extractSubprojectLanguage(projectName, childProjectName));
             });
         } else if (project.hasProperty(GENERIC_GENERATOR_LANGUAGE_NAMES_PROPERTY)) {
             String names = (String) project.getProperties().get(GENERIC_GENERATOR_LANGUAGE_NAMES_PROPERTY);

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -567,7 +567,7 @@ public final class ConjurePlugin implements Plugin<Project> {
             return Maps.filterKeys(project.getChildProjects(), childProjectName -> {
                 return childProjectName.startsWith(projectName)
                         && !FIRST_CLASS_GENERATOR_PROJECT_NAMES.contains(
-                        extractSubprojectLanguage(projectName, childProjectName));
+                                extractSubprojectLanguage(projectName, childProjectName));
             });
         } else if (project.hasProperty(GENERIC_GENERATOR_LANGUAGE_NAMES_PROPERTY)) {
             String names = (String) project.getProperties().get(GENERIC_GENERATOR_LANGUAGE_NAMES_PROPERTY);

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPluginIntegrationSpec.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPluginIntegrationSpec.groovy
@@ -46,8 +46,8 @@ class ConjureJavaLocalCodegenPluginIntegrationSpec extends IntegrationSpec {
 
                    force 'com.fasterxml.jackson.core:jackson-databind:2.10.2'
                    force 'com.fasterxml.jackson.core:jackson-annotations:2.10.2'
-                   force 'com.palantir.safe-logging:safe-logging:1.12.0'
-                   force 'com.palantir.safe-logging:preconditions:1.12.0'
+                   force 'com.palantir.safe-logging:safe-logging:${TestVersions.SAFE_LOGGING}'
+                   force 'com.palantir.safe-logging:preconditions:${TestVersions.SAFE_LOGGING}'
                }
            }
         }

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -509,6 +509,31 @@ class ConjurePluginTest extends IntegrationSpec {
         'peer'     | ''
     }
 
+    def 'featureFlag jakartaPackages can be enabled: #location'() {
+        file('api/build.gradle') << '''
+        conjure {
+            java {
+                jakartaPackages = true
+            }
+        }
+        '''.stripIndent()
+        updateSettings(prefix)
+
+        when:
+        runTasksSuccessfully(':api:compileConjureJersey')
+
+        then:
+        def serviceFile = prefixPath(prefix, 'api-jersey/src/generated/java/test/test/api/TestServiceFoo.java')
+        fileExists(serviceFile)
+        file(serviceFile).text.contains("import javax.annotation.processing.Generated;")
+        file(serviceFile).text.contains("import jakarta.ws.rs.Produces;")
+
+        where:
+        location   | prefix
+        'sub'      | 'api'
+        'peer'     | ''
+    }
+
     def 'typescript extension is respected: #location'() {
         file('api/build.gradle') << '''
         conjure {

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -66,6 +66,7 @@ class ConjurePluginTest extends IntegrationSpec {
                    force 'com.palantir.conjure:conjure:${TestVersions.CONJURE}'
                    force 'com.palantir.conjure.typescript:conjure-typescript:${TestVersions.CONJURE_TYPESCRIPT}'
 
+                   force 'javax.ws.rs:javax.ws.rs-api:2.1.1'
                    force 'com.fasterxml.jackson.core:jackson-annotations:2.10.2'
                    force 'com.fasterxml.jackson.core:jackson-databind:2.10.2'
                    force 'com.google.guava:guava:23.6.1-jre'

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -66,7 +66,6 @@ class ConjurePluginTest extends IntegrationSpec {
                    force 'com.palantir.conjure:conjure:${TestVersions.CONJURE}'
                    force 'com.palantir.conjure.typescript:conjure-typescript:${TestVersions.CONJURE_TYPESCRIPT}'
 
-                   force 'javax.ws.rs:javax.ws.rs-api:2.1.1'
                    force 'com.fasterxml.jackson.core:jackson-annotations:2.10.2'
                    force 'com.fasterxml.jackson.core:jackson-databind:2.10.2'
                    force 'com.google.guava:guava:23.6.1-jre'

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
@@ -54,6 +54,7 @@ class ConjureServiceDependencyTest extends IntegrationSpec {
                     force 'com.palantir.conjure.java:conjure-undertow-lib:${TestVersions.CONJURE_JAVA}'
                     force 'com.palantir.conjure:conjure:${TestVersions.CONJURE}'
                     force 'com.palantir.conjure.typescript:conjure-typescript:${TestVersions.CONJURE_TYPESCRIPT}'
+                    force 'javax.ws.rs:javax.ws.rs-api:2.1.1'
                 }
             }   
         }

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
@@ -54,7 +54,6 @@ class ConjureServiceDependencyTest extends IntegrationSpec {
                     force 'com.palantir.conjure.java:conjure-undertow-lib:${TestVersions.CONJURE_JAVA}'
                     force 'com.palantir.conjure:conjure:${TestVersions.CONJURE}'
                     force 'com.palantir.conjure.typescript:conjure-typescript:${TestVersions.CONJURE_TYPESCRIPT}'
-                    force 'javax.ws.rs:javax.ws.rs-api:2.1.1'
                 }
             }   
         }

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/TestVersions.java
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/TestVersions.java
@@ -25,4 +25,6 @@ public final class TestVersions {
     public static final String CONJURE_PYTHON = "3.11.6";
     public static final String CONJURE_TYPESCRIPT = "3.8.1";
     public static final String CONJURE_POSTMAN = "0.1.2";
+
+    public static final String SAFE_LOGGING = "3.0.0";
 }

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/TestVersions.java
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/TestVersions.java
@@ -20,8 +20,8 @@ public final class TestVersions {
     private TestVersions() {}
 
     public static final String CONJURE = "4.30.0";
-    public static final String CONJURE_JAVA = "5.17.0";
-    public static final String CONJURE_JAVA_DIALOG = "1.50.0";
+    public static final String CONJURE_JAVA = "6.61.0";
+    public static final String CONJURE_JAVA_DIALOG = "3.65.0";
     public static final String CONJURE_PYTHON = "3.11.6";
     public static final String CONJURE_TYPESCRIPT = "3.8.1";
     public static final String CONJURE_POSTMAN = "0.1.2";


### PR DESCRIPTION

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Prefer Javax versions instead of the Jakarta Versions

The jakarta versions were fine, until the Jakarta EE9 releases, where
for example:

javax.ws.rs:javax.ws.rs-api 2.0.0 -> jakarta.ws.rs:jakarta.ws.rs-api 2.1.6

was totally fine. However, once going to:

jakarta.ws.rs:jakarta.ws.rs-api 2.1.6 -> jakarta.ws.rs:jakarta.ws.rs-api 3.0.0

we are no longer able to trivially make that version change.

In order to better handle other plugins like Gradle Consistent Versions,
which lock all modules with the same identifier into the same version,
we have to make this plugin depend on the legacy javax versions of some
APIs, such that can can have both 2.0.0 and 3.0.0 on the classpath at
the same time.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

This change effectively drops full support for JDK8 and earlier.
