### PR TITLE
Java generators automatically opt into jetbrains contract info on errors

### DIFF
--- a/changelog/@unreleased/pr-1105.v2.yml
+++ b/changelog/@unreleased/pr-1105.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Java generators automatically opt into jetbrains contract info on errors
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/1105

--- a/gradle-conjure-api/src/main/java/com/palantir/gradle/conjure/api/ConjureExtension.java
+++ b/gradle-conjure-api/src/main/java/com/palantir/gradle/conjure/api/ConjureExtension.java
@@ -31,6 +31,14 @@ public class ConjureExtension {
     private final GeneratorOptions pythonOptions = new GeneratorOptions();
     private final Map<String, GeneratorOptions> genericOptions = new HashMap<>();
 
+    public ConjureExtension() {
+        // Projects using sufficiently new gradle-conjure have jetbrains-annotations
+        // added by default. Conjure generators ignore unknown flags and will not be
+        // impacted if generators have not been updated.
+        // See https://github.com/palantir/conjure-java/pull/1884
+        javaOptions.addFlag("jetbrainsContractAnnotations");
+    }
+
     public final void typescript(
             // rawtypes to support idea integration
             @DelegatesTo(GeneratorOptions.class) @SuppressWarnings("rawtypes") Closure closure) {

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -109,8 +109,9 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
             TaskProvider<Copy> extractConjureIr) {
         ConjurePlugin.addGeneratedToMainSourceSet(project);
 
-        project.getDependencies().add("api", "com.palantir.conjure.java:conjure-lib");
-        project.getDependencies().add("compileOnly", ConjurePlugin.ANNOTATION_API);
+        project.getDependencies().add("api", Dependencies.CONJURE_JAVA_LIB);
+        project.getDependencies().add("implementation", Dependencies.JETBRAINS_ANNOTATIONS);
+        project.getDependencies().add("compileOnly", Dependencies.ANNOTATION_API);
 
         TaskProvider<WriteGitignoreTask> generateGitIgnore = ConjurePlugin.createWriteGitignoreTask(
                 project, "gitignoreConjure", project.getProjectDir(), ConjurePlugin.JAVA_GITIGNORE_CONTENTS);

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/Dependencies.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/Dependencies.java
@@ -1,0 +1,35 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.conjure;
+
+final class Dependencies {
+
+    /** Make the old Java8 @Generated annotation available even when compiling with Java9+. */
+    static final String ANNOTATION_API = "jakarta.annotation:jakarta.annotation-api:1.3.5";
+
+    static final String CONJURE_JAVA_LIB = "com.palantir.conjure.java:conjure-lib";
+    static final String CONJURE_UNDERTOW_LIB = "com.palantir.conjure.java:conjure-undertow-lib";
+    static final String DIALOGUE_TARGET = "com.palantir.dialogue:dialogue-target";
+    static final String JAXRS_API = "jakarta.ws.rs:jakarta.ws.rs-api";
+    /**
+     * Includes a version in order to ensure upgrades that opt into annotations
+     * have a minimum version rather than failing builds.
+     */
+    static final String JETBRAINS_ANNOTATIONS = "org.jetbrains:annotations:23.0.0";
+
+    private Dependencies() {}
+}

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPluginIntegrationSpec.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPluginIntegrationSpec.groovy
@@ -84,8 +84,8 @@ class ConjureJavaLocalCodegenPluginIntegrationSpec extends IntegrationSpec {
         result.wasExecuted("conjure-api:generateConjure")
         fileExists("build/conjure-ir/conjure-api.conjure.json")
         fileExists('conjure-api/src/generated/java/test/groupwithdashes/com/palantir/conjure/spec/ConjureDefinition.java')
-        result.standardOutput.contains "with args: [--jersey, --packagePrefix=test.groupwithdashes]"
-        result.standardOutput.contains "with args: [--objects, --packagePrefix=test.groupwithdashes]"
+        result.standardOutput.contains "with args: [--jersey, --jetbrainsContractAnnotations, --packagePrefix=test.groupwithdashes]"
+        result.standardOutput.contains "with args: [--jetbrainsContractAnnotations, --objects, --packagePrefix=test.groupwithdashes]"
     }
 
     def "respects user provided packagePrefix"() {
@@ -105,7 +105,7 @@ class ConjureJavaLocalCodegenPluginIntegrationSpec extends IntegrationSpec {
         then:
         result.wasExecuted("extractConjureIr")
         fileExists('conjure-api/src/generated/java/user/group/com/palantir/conjure/spec/ConjureDefinition.java')
-        result.standardOutput.contains "with args: [--objects, --packagePrefix=user.group]"
+        result.standardOutput.contains "with args: [--jetbrainsContractAnnotations, --objects, --packagePrefix=user.group]"
     }
 
     def 'check code compiles'() {


### PR DESCRIPTION
For more information on this feature, see
https://github.com/palantir/conjure-java/pull/1884

==COMMIT_MSG==
Java generators automatically opt into jetbrains contract info on errors
==COMMIT_MSG==

