### PR TITLE
conjure-java-local applies pdeps using standard mechanisms

### DIFF
--- a/changelog/@unreleased/pr-1123.v2.yml
+++ b/changelog/@unreleased/pr-1123.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: conjure-java-local applies pdeps using standard mechanisms, adding
+    dependency information correctly to the jar resource in addition to the jar manifest
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/1123

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -21,8 +21,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.gradle.conjure.api.ConjureExtension;
-import com.palantir.gradle.dist.ConfigureProductDependenciesTask;
 import com.palantir.gradle.dist.ProductDependency;
+import com.palantir.gradle.dist.RecommendedProductDependenciesExtension;
 import com.palantir.gradle.dist.RecommendedProductDependenciesPlugin;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.io.File;
@@ -118,13 +118,11 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
 
         Provider<File> conjureIrFile = extractConjureIr.map(
                 irTask -> new File(irTask.getDestinationDir(), project.getName() + ".conjure.json"));
-        project.getTasks()
-                .named("configureProductDependencies", ConfigureProductDependenciesTask.class)
-                .configure(task -> {
-                    task.setProductDependencies(
-                            conjureIrFile.map(ConjureJavaLocalCodegenPlugin::extractProductDependencies));
-                    task.dependsOn(extractConjureIr);
-                });
+
+        project.getExtensions()
+                .getByType(RecommendedProductDependenciesExtension.class)
+                .getRecommendedProductDependenciesProvider()
+                .set(conjureIrFile.map(ConjureJavaLocalCodegenPlugin::extractProductDependencies));
 
         TaskProvider<ConjureJavaLocalGeneratorTask> generateJava = project.getTasks()
                 .register("generateConjure", ConjureJavaLocalGeneratorTask.class, task -> {


### PR DESCRIPTION
Note that this won't support per-endpoint dependencies, but reuses shared logic with the standard conjure-java plugin describing product deps.

==COMMIT_MSG==
conjure-java-local applies pdeps using standard mechanisms, adding dependency information correctly to the jar resource in addition to the jar manifest
==COMMIT_MSG==