### PR TITLE
Fix exact dependency check failures in conjure-java-local

### DIFF
--- a/changelog/@unreleased/pr-1124.v2.yml
+++ b/changelog/@unreleased/pr-1124.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix exact dependency check failures in conjure-java-local
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/1124

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -107,6 +107,7 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
             ConjureExtension extension,
             TaskProvider<ExtractExecutableTask> extractJavaTask,
             TaskProvider<Copy> extractConjureIr) {
+        ConjurePlugin.ignoreFromCheckUnusedDependencies(project);
         ConjurePlugin.addGeneratedToMainSourceSet(project);
 
         project.getDependencies().add("api", Dependencies.CONJURE_JAVA_LIB);

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -295,7 +295,7 @@ public final class ConjurePlugin implements Plugin<Project> {
     }
 
     @SuppressWarnings({"unchecked", "RawTypes"})
-    private static void ignoreFromCheckUnusedDependencies(Project proj) {
+    static void ignoreFromCheckUnusedDependencies(Project proj) {
         proj.getPlugins().withId("com.palantir.baseline-exact-dependencies", plugin -> {
             Class<? extends Task> checkUnusedDependenciesTask;
             try {


### PR DESCRIPTION
## Before this PR
Previously these only worked properly in the more common remote codegen path.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix exact dependency check failures in conjure-java-local
==COMMIT_MSG==

