### PR TITLE
consider 'useJakartaNamespaces' option when setting up dependencies

### DIFF
--- a/changelog/@unreleased/pr-1155.v2.yml
+++ b/changelog/@unreleased/pr-1155.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: by default gradle-conjure will generate a project with the older "javax"
+    dependencies unless "useJakartaNamespaces" is set to true, and then it will select
+    the newer "jakarta" dependencies.
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/1155

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -112,7 +112,11 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
 
         project.getDependencies().add("api", Dependencies.CONJURE_JAVA_LIB);
         project.getDependencies().add("implementation", Dependencies.JETBRAINS_ANNOTATIONS);
-        project.getDependencies().add("compileOnly", Dependencies.ANNOTATION_API);
+        boolean useJakarta = Dependencies.isUseJakartaNamespaces(extension.getJava());
+        project.getDependencies()
+                .add(
+                        "compileOnly",
+                        useJakarta ? Dependencies.ANNOTATION_API_JAKARTA : Dependencies.ANNOTATION_API_JAVAX);
 
         TaskProvider<WriteGitignoreTask> generateGitIgnore = ConjurePlugin.createWriteGitignoreTask(
                 project, "gitignoreConjure", project.getProjectDir(), ConjurePlugin.JAVA_GITIGNORE_CONTENTS);

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -281,8 +281,7 @@ public final class ConjurePlugin implements Plugin<Project> {
     }
 
     private static void setupRetrofitProject(Project project, Supplier<GeneratorOptions> optionsSupplier) {
-        boolean useJakarta = optionsSupplier.get().has("useJakartaNamespaces")
-                && ((Boolean) optionsSupplier.get().get("useJakartaNamespaces"));
+        boolean useJakarta = Dependencies.isUseJakartaNamespaces(optionsSupplier.get());
         project.getDependencies().add("api", "com.google.guava:guava");
         project.getDependencies().add("api", "com.squareup.retrofit2:retrofit");
         project.getDependencies()
@@ -292,8 +291,7 @@ public final class ConjurePlugin implements Plugin<Project> {
     }
 
     private static void setupJerseyProject(Project project, Supplier<GeneratorOptions> optionsSupplier) {
-        boolean useJakarta = optionsSupplier.get().has("useJakartaNamespaces")
-                && ((Boolean) optionsSupplier.get().get("useJakartaNamespaces"));
+        boolean useJakarta = Dependencies.isUseJakartaNamespaces(optionsSupplier.get());
         project.getDependencies()
                 .add("api", useJakarta ? Dependencies.JAXRS_API_JAKARTA : Dependencies.JAXRS_API_JAVAX);
         project.getDependencies()

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -152,13 +152,14 @@ public final class ConjurePlugin implements Plugin<Project> {
 
         TaskProvider<ExtractExecutableTask> extractJavaTask = ExtractConjurePlugin.applyConjureJava(project);
 
-        Map<String, Consumer<Project>> configs = ImmutableMap.<String, Consumer<Project>>builder()
-                .put(JAVA_OBJECTS_SUFFIX, (Consumer<Project>) ConjurePlugin::setupObjectsProject)
-                .put(JAVA_DIALOGUE_SUFFIX, (Consumer<Project>) ConjurePlugin::setupDialogueProject)
-                .put(JAVA_RETROFIT_SUFFIX, (Consumer<Project>) ConjurePlugin::setupRetrofitProject)
-                .put(JAVA_JERSEY_SUFFIX, (Consumer<Project>) ConjurePlugin::setupJerseyProject)
-                .put(JAVA_UNDERTOW_SUFFIX, (Consumer<Project>) ConjurePlugin::setupUndertowProject)
-                .buildOrThrow();
+        Map<String, BiConsumer<Project, Supplier<GeneratorOptions>>> configs =
+                ImmutableMap.<String, BiConsumer<Project, Supplier<GeneratorOptions>>>builder()
+                        .put(JAVA_OBJECTS_SUFFIX, ConjurePlugin::setupObjectsProject)
+                        .put(JAVA_DIALOGUE_SUFFIX, ConjurePlugin::setupDialogueProject)
+                        .put(JAVA_RETROFIT_SUFFIX, ConjurePlugin::setupRetrofitProject)
+                        .put(JAVA_JERSEY_SUFFIX, ConjurePlugin::setupJerseyProject)
+                        .put(JAVA_UNDERTOW_SUFFIX, ConjurePlugin::setupUndertowProject)
+                        .buildOrThrow();
 
         // Make sure project names align
         Sets.SetView<String> difference = Sets.difference(configs.keySet(), JAVA_PROJECT_SUFFIXES);
@@ -188,7 +189,7 @@ public final class ConjurePlugin implements Plugin<Project> {
             TaskProvider<?> compileIrTask,
             ConjureProductDependenciesExtension productDependencyExt,
             TaskProvider<ExtractExecutableTask> extractJavaTask,
-            Consumer<Project> extraConfig) {
+            BiConsumer<Project, Supplier<GeneratorOptions>> extraConfig) {
         String projectName = getDerivedProjectName(parentProject, projectSuffix);
         if (!derivedProjectExists(parentProject, projectName)) {
             return null;
@@ -236,7 +237,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                 ConjureJavaServiceDependencies.configureJavaServiceDependencies(subproj, productDependencyExt);
             }
             if (extraConfig != null) {
-                extraConfig.accept(subproj);
+                extraConfig.accept(subproj, optionsSupplier);
             }
         });
     }
@@ -270,27 +271,38 @@ public final class ConjurePlugin implements Plugin<Project> {
         return !(projectName.endsWith(JAVA_OBJECTS_SUFFIX) || projectName.endsWith(JAVA_UNDERTOW_SUFFIX));
     }
 
-    private static void setupObjectsProject(Project project) {
+    private static void setupObjectsProject(Project project, Supplier<GeneratorOptions> _optionsSupplier) {
         project.getDependencies().add("api", Dependencies.CONJURE_JAVA_LIB);
         project.getDependencies().add("implementation", Dependencies.JETBRAINS_ANNOTATIONS);
     }
 
-    private static void setupDialogueProject(Project project) {
+    private static void setupDialogueProject(Project project, Supplier<GeneratorOptions> _optionsSupplier) {
         project.getDependencies().add("api", Dependencies.DIALOGUE_TARGET);
     }
 
-    private static void setupRetrofitProject(Project project) {
+    private static void setupRetrofitProject(Project project, Supplier<GeneratorOptions> optionsSupplier) {
+        boolean useJakarta = optionsSupplier.get().has("useJakartaNamespaces")
+                && ((Boolean) optionsSupplier.get().get("useJakartaNamespaces"));
         project.getDependencies().add("api", "com.google.guava:guava");
         project.getDependencies().add("api", "com.squareup.retrofit2:retrofit");
-        project.getDependencies().add("compileOnly", Dependencies.ANNOTATION_API);
+        project.getDependencies()
+                .add(
+                        "compileOnly",
+                        useJakarta ? Dependencies.ANNOTATION_API_JAKARTA : Dependencies.ANNOTATION_API_JAVAX);
     }
 
-    private static void setupJerseyProject(Project project) {
-        project.getDependencies().add("api", Dependencies.JAXRS_API);
-        project.getDependencies().add("compileOnly", Dependencies.ANNOTATION_API);
+    private static void setupJerseyProject(Project project, Supplier<GeneratorOptions> optionsSupplier) {
+        boolean useJakarta = optionsSupplier.get().has("useJakartaNamespaces")
+                && ((Boolean) optionsSupplier.get().get("useJakartaNamespaces"));
+        project.getDependencies()
+                .add("api", useJakarta ? Dependencies.JAXRS_API_JAKARTA : Dependencies.JAXRS_API_JAVAX);
+        project.getDependencies()
+                .add(
+                        "compileOnly",
+                        useJakarta ? Dependencies.ANNOTATION_API_JAKARTA : Dependencies.ANNOTATION_API_JAVAX);
     }
 
-    private static void setupUndertowProject(Project project) {
+    private static void setupUndertowProject(Project project, Supplier<GeneratorOptions> _optionsSupplier) {
         project.getDependencies().add("api", Dependencies.CONJURE_UNDERTOW_LIB);
     }
 

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/Dependencies.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/Dependencies.java
@@ -16,23 +16,30 @@
 
 package com.palantir.gradle.conjure;
 
+import com.palantir.gradle.conjure.api.GeneratorOptions;
+
 final class Dependencies {
 
-    /** Make the old Java8 @Generated annotation available even when compiling with Java9+. */
-    static final String ANNOTATION_API_JAKARTA = "jakarta.annotation:jakarta.annotation-api:1.3.5";
-
+    // Make the old Java8 @Generated annotation available even when compiling with Java9+.
+    static final String ANNOTATION_API_JAKARTA = "jakarta.annotation:jakarta.annotation-api:2.0.0";
     static final String ANNOTATION_API_JAVAX = "javax.annotation:javax.annotation-api:1.3.2";
+    static final String JAXRS_API_JAKARTA = "jakarta.ws.rs:jakarta.ws.rs-api:3.0.0";
+    static final String JAXRS_API_JAVAX = "javax.ws.rs:javax.ws.rs-api:2.1.1";
 
     static final String CONJURE_JAVA_LIB = "com.palantir.conjure.java:conjure-lib";
     static final String CONJURE_UNDERTOW_LIB = "com.palantir.conjure.java:conjure-undertow-lib";
     static final String DIALOGUE_TARGET = "com.palantir.dialogue:dialogue-target";
-    static final String JAXRS_API_JAKARTA = "jakarta.ws.rs:jakarta.ws.rs-api";
-    static final String JAXRS_API_JAVAX = "javax.ws.rs:javax.ws.rs-api";
     /**
      * Includes a version in order to ensure upgrades that opt into annotations
      * have a minimum version rather than failing builds.
      */
     static final String JETBRAINS_ANNOTATIONS = "org.jetbrains:annotations:23.0.0";
+
+    private static final String USE_JAKARTA_NAMESPACES = "useJakartaNamespaces";
+
+    static boolean isUseJakartaNamespaces(GeneratorOptions options) {
+        return options.has(USE_JAKARTA_NAMESPACES) && Boolean.TRUE.equals(options.get(USE_JAKARTA_NAMESPACES));
+    }
 
     private Dependencies() {}
 }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/Dependencies.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/Dependencies.java
@@ -19,12 +19,15 @@ package com.palantir.gradle.conjure;
 final class Dependencies {
 
     /** Make the old Java8 @Generated annotation available even when compiling with Java9+. */
-    static final String ANNOTATION_API = "jakarta.annotation:jakarta.annotation-api:1.3.5";
+    static final String ANNOTATION_API_JAKARTA = "jakarta.annotation:jakarta.annotation-api:1.3.5";
+
+    static final String ANNOTATION_API_JAVAX = "javax.annotation:javax.annotation-api:1.3.2";
 
     static final String CONJURE_JAVA_LIB = "com.palantir.conjure.java:conjure-lib";
     static final String CONJURE_UNDERTOW_LIB = "com.palantir.conjure.java:conjure-undertow-lib";
     static final String DIALOGUE_TARGET = "com.palantir.dialogue:dialogue-target";
-    static final String JAXRS_API = "jakarta.ws.rs:jakarta.ws.rs-api";
+    static final String JAXRS_API_JAKARTA = "jakarta.ws.rs:jakarta.ws.rs-api";
+    static final String JAXRS_API_JAVAX = "javax.ws.rs:javax.ws.rs-api";
     /**
      * Includes a version in order to ensure upgrades that opt into annotations
      * have a minimum version rather than failing builds.


### PR DESCRIPTION
## Before this PR
Previously, ConjurePlugin would apply only "jakarta" dependencies to java subprojects, but this allows projects that are using Jakarta dependencies for which resolution has selected a higher version that has the newer "jakarta" namespace to possibly be inconsistent with the "useJakartaNamespaces" flag (for instance, if the flag were set to false, it would generate code that would not work, and possibly vice-versa).

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
by default gradle-conjure will generate a project with the older "javax" dependencies unless "useJakartaNamespaces" is set to true, and then it will select the newer "jakarta" dependencies.
==COMMIT_MSG==

## Possible downsides?
It's possible that a project which does not use https://github.com/palantir/jakarta-package-alignment will end up in a state where other projects use jakarta libs, but generated conjure projects use javax libs.