### PR TITLE
fix test for 'jakartaPackages' generator flag

### DIFF
--- a/changelog/@unreleased/pr-1158.v2.yml
+++ b/changelog/@unreleased/pr-1158.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Test for the correct 'jakartaPackages' flag when generating dependencies.
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/1158

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -112,7 +112,7 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
 
         project.getDependencies().add("api", Dependencies.CONJURE_JAVA_LIB);
         project.getDependencies().add("implementation", Dependencies.JETBRAINS_ANNOTATIONS);
-        boolean useJakarta = Dependencies.isUseJakartaNamespaces(extension.getJava());
+        boolean useJakarta = Dependencies.isJakartaPackages(extension.getJava());
         project.getDependencies()
                 .add(
                         "compileOnly",

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -281,7 +281,7 @@ public final class ConjurePlugin implements Plugin<Project> {
     }
 
     private static void setupRetrofitProject(Project project, Supplier<GeneratorOptions> optionsSupplier) {
-        boolean useJakarta = Dependencies.isUseJakartaNamespaces(optionsSupplier.get());
+        boolean useJakarta = Dependencies.isJakartaPackages(optionsSupplier.get());
         project.getDependencies().add("api", "com.google.guava:guava");
         project.getDependencies().add("api", "com.squareup.retrofit2:retrofit");
         project.getDependencies()
@@ -291,7 +291,7 @@ public final class ConjurePlugin implements Plugin<Project> {
     }
 
     private static void setupJerseyProject(Project project, Supplier<GeneratorOptions> optionsSupplier) {
-        boolean useJakarta = Dependencies.isUseJakartaNamespaces(optionsSupplier.get());
+        boolean useJakarta = Dependencies.isJakartaPackages(optionsSupplier.get());
         project.getDependencies()
                 .add("api", useJakarta ? Dependencies.JAXRS_API_JAKARTA : Dependencies.JAXRS_API_JAVAX);
         project.getDependencies()

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/Dependencies.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/Dependencies.java
@@ -35,10 +35,10 @@ final class Dependencies {
      */
     static final String JETBRAINS_ANNOTATIONS = "org.jetbrains:annotations:23.0.0";
 
-    private static final String USE_JAKARTA_NAMESPACES = "useJakartaNamespaces";
+    private static final String JAKARTA_PACKAGES = "jakartaPackages";
 
-    static boolean isUseJakartaNamespaces(GeneratorOptions options) {
-        return options.has(USE_JAKARTA_NAMESPACES) && Boolean.TRUE.equals(options.get(USE_JAKARTA_NAMESPACES));
+    static boolean isJakartaPackages(GeneratorOptions options) {
+        return options.has(JAKARTA_PACKAGES) && Boolean.TRUE.equals(options.get(JAKARTA_PACKAGES));
     }
 
     private Dependencies() {}


### PR DESCRIPTION

## Before this PR
This previously looked for a flag called 'useJakartaNamespaces', which was wrong.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Test for the correct 'jakartaPackages' flag when generating dependencies.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

