### PR TITLE
wrap setupDerivedProjects in afterEvaluate block

### DIFF
--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -170,7 +170,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                             + difference);
         }
 
-        configs.forEach((suffix, config) -> setupDerivedJavaProject(
+        project.afterEvaluate(_p -> configs.forEach((suffix, config) -> setupDerivedJavaProject(
                 suffix,
                 project,
                 optionsSupplier,
@@ -178,7 +178,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                 compileIrTask,
                 productDependencyExt,
                 extractJavaTask,
-                config));
+                config)));
     }
 
     private static Project setupDerivedJavaProject(


### PR DESCRIPTION
without this, in some cases it seems like sometimes the ConjureExtension object is not actually populated with values parsed from the build script at the time that we need them to add dependencies on subprojects. This is problematic when e.g. the "jakartaPackages" flag is set, because it changes the set of dependencies we need to add.
