### PR TITLE
conjure-java-local adds correct dependencies

### DIFF
--- a/changelog/@unreleased/pr-1200.v2.yml
+++ b/changelog/@unreleased/pr-1200.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: conjure-java-local adds correct dependencies for jaxrs, dialogue, and
+    conjure-undertow generated code.
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/1200

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -81,7 +81,8 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
 
         project.afterEvaluate(_p -> {
             project.getChildProjects().forEach((_name, subproject) -> {
-                // Configure subproject dependencies in after-evaluate to ensure the has been evaluated.
+                // Configure subproject dependencies in after-evaluate to ensure
+                // extension the has been evaluated.
                 configureDependencies(subproject, extension);
             });
             // Validating that each subproject has a corresponding definition and vice versa.

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -73,10 +73,19 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
             TaskProvider<ExtractExecutableTask> extractJavaTask,
             TaskProvider<Copy> extractConjureIr,
             Configuration conjureIrConfiguration) {
+        project.getChildProjects().forEach((_name, subproject) -> {
+            subproject.getPluginManager().apply(JavaLibraryPlugin.class);
+            subproject.getPluginManager().apply(RecommendedProductDependenciesPlugin.class);
+            createGenerateTask(subproject, extension, extractJavaTask, extractConjureIr);
+        });
 
-        // Validating that each subproject has a corresponding definition and vice versa.
-        // We do this in afterEvaluate to ensure the configuration is populated.
         project.afterEvaluate(_p -> {
+            project.getChildProjects().forEach((_name, subproject) -> {
+                // Configure subproject dependencies in after-evaluate to ensure the has been evaluated.
+                configureDependencies(subproject, extension);
+            });
+            // Validating that each subproject has a corresponding definition and vice versa.
+            // We do this in afterEvaluate to ensure the configuration is populated.
             Set<String> apis = conjureIrConfiguration.getAllDependencies().stream()
                     .map(Dependency::getName)
                     .collect(ImmutableSet.toImmutableSet());
@@ -94,12 +103,26 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
                         String.format("Discovered subprojects %s without corresponding dependencies.", missingApis));
             }
         });
+    }
 
-        project.getChildProjects().forEach((_name, subproject) -> {
-            subproject.getPluginManager().apply(JavaLibraryPlugin.class);
-            subproject.getPluginManager().apply(RecommendedProductDependenciesPlugin.class);
-            createGenerateTask(subproject, extension, extractJavaTask, extractConjureIr);
-        });
+    private static void configureDependencies(Project project, ConjureExtension extension) {
+        project.getDependencies().add("api", Dependencies.CONJURE_JAVA_LIB);
+        project.getDependencies().add("api", Dependencies.JETBRAINS_ANNOTATIONS);
+        boolean useJakarta = Dependencies.isJakartaPackages(extension.getJava());
+        project.getDependencies()
+                .add(
+                        "compileOnly",
+                        useJakarta ? Dependencies.ANNOTATION_API_JAKARTA : Dependencies.ANNOTATION_API_JAVAX);
+        if (Dependencies.isJersey(extension.getJava())) {
+            project.getDependencies()
+                    .add("api", useJakarta ? Dependencies.JAXRS_API_JAKARTA : Dependencies.JAXRS_API_JAVAX);
+        }
+        if (Dependencies.isDialogue(extension.getJava())) {
+            project.getDependencies().add("api", Dependencies.DIALOGUE_TARGET);
+        }
+        if (Dependencies.isUndertow(extension.getJava())) {
+            project.getDependencies().add("api", Dependencies.CONJURE_UNDERTOW_LIB);
+        }
     }
 
     private static void createGenerateTask(
@@ -109,14 +132,6 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
             TaskProvider<Copy> extractConjureIr) {
         ConjurePlugin.ignoreFromCheckUnusedDependencies(project);
         ConjurePlugin.addGeneratedToMainSourceSet(project);
-
-        project.getDependencies().add("api", Dependencies.CONJURE_JAVA_LIB);
-        project.getDependencies().add("implementation", Dependencies.JETBRAINS_ANNOTATIONS);
-        boolean useJakarta = Dependencies.isJakartaPackages(extension.getJava());
-        project.getDependencies()
-                .add(
-                        "compileOnly",
-                        useJakarta ? Dependencies.ANNOTATION_API_JAKARTA : Dependencies.ANNOTATION_API_JAVAX);
 
         TaskProvider<WriteGitignoreTask> generateGitIgnore = ConjurePlugin.createWriteGitignoreTask(
                 project, "gitignoreConjure", project.getProjectDir(), ConjurePlugin.JAVA_GITIGNORE_CONTENTS);

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -276,7 +276,7 @@ public final class ConjurePlugin implements Plugin<Project> {
 
     private static void setupObjectsProject(Project project, Supplier<GeneratorOptions> _optionsSupplier) {
         project.getDependencies().add("api", Dependencies.CONJURE_JAVA_LIB);
-        project.getDependencies().add("implementation", Dependencies.JETBRAINS_ANNOTATIONS);
+        project.getDependencies().add("api", Dependencies.JETBRAINS_ANNOTATIONS);
     }
 
     private static void setupDialogueProject(Project project, Supplier<GeneratorOptions> _optionsSupplier) {

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/Dependencies.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/Dependencies.java
@@ -36,9 +36,24 @@ final class Dependencies {
     static final String JETBRAINS_ANNOTATIONS = "org.jetbrains:annotations:23.0.0";
 
     private static final String JAKARTA_PACKAGES = "jakartaPackages";
+    private static final String JERSEY = "jersey";
+    private static final String DIALOGUE = "dialogue";
+    private static final String UNDERTOW = "undertow";
 
     static boolean isJakartaPackages(GeneratorOptions options) {
         return options.has(JAKARTA_PACKAGES) && Boolean.TRUE.equals(options.get(JAKARTA_PACKAGES));
+    }
+
+    static boolean isJersey(GeneratorOptions options) {
+        return options.has(JERSEY) && Boolean.TRUE.equals(options.get(JERSEY));
+    }
+
+    static boolean isDialogue(GeneratorOptions options) {
+        return options.has(DIALOGUE) && Boolean.TRUE.equals(options.get(DIALOGUE));
+    }
+
+    static boolean isUndertow(GeneratorOptions options) {
+        return options.has(UNDERTOW) && Boolean.TRUE.equals(options.get(UNDERTOW));
     }
 
     private Dependencies() {}


### PR DESCRIPTION
This matches the fix in our check for the standard server-codegen path, but also updates the conjure-java-local plugin to add jax-rs, dialogue, and undertow dependencies as requested by the codegen task.

==COMMIT_MSG==
conjure-java-local adds correct dependencies for jaxrs, dialogue, and conjure-undertow generated code.
==COMMIT_MSG==

Ideally I'd have test coverage which captures the failure, however the existing tests use published definitions for conjure itself, which don't include any services. This unblocks server upgrades, so I'm biasing toward getting it out quickly. I've verified that this works in one of the blocked projects.