### PR TITLE
remove afterEvaluate in some places

### DIFF
--- a/changelog/@unreleased/pr-1246.v2.yml
+++ b/changelog/@unreleased/pr-1246.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Dependencies for subprojects are now added via an `addProvider` instead
+    which defers execution of the code that adds the dependencies until the project
+    is actually configured, by which time the extension values have been populated.
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/1246

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -93,8 +93,8 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
             Sets.SetView<String> missingProjects =
                     Sets.difference(apis, project.getChildProjects().keySet());
             if (!missingProjects.isEmpty()) {
-                throw new RuntimeException(
-                        String.format("Discovered dependencies %s without corresponding subprojects.", missingProjects));
+                throw new RuntimeException(String.format(
+                        "Discovered dependencies %s without corresponding subprojects.", missingProjects));
             }
             Sets.SetView<String> missingApis =
                     Sets.difference(project.getChildProjects().keySet(), apis);

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -80,28 +80,29 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
         });
 
         project.getChildProjects().forEach((_name, subproject) -> {
-            // Configure subproject dependencies in after-evaluate to ensure
-            // extension the has been evaluated.
             configureDependencies(subproject, extension);
         });
-        // Validating that each subproject has a corresponding definition and vice versa.
-        // We do this in afterEvaluate to ensure the configuration is populated.
-        Set<String> apis = conjureIrConfiguration.getAllDependencies().stream()
-                .map(Dependency::getName)
-                .collect(ImmutableSet.toImmutableSet());
 
-        Sets.SetView<String> missingProjects =
-                Sets.difference(apis, project.getChildProjects().keySet());
-        if (!missingProjects.isEmpty()) {
-            throw new RuntimeException(
-                    String.format("Discovered dependencies %s without corresponding subprojects.", missingProjects));
-        }
-        Sets.SetView<String> missingApis =
-                Sets.difference(project.getChildProjects().keySet(), apis);
-        if (!missingApis.isEmpty()) {
-            throw new RuntimeException(
-                    String.format("Discovered subprojects %s without corresponding dependencies.", missingApis));
-        }
+        project.afterEvaluate(_p -> {
+            // Validating that each subproject has a corresponding definition and vice versa.
+            // We do this in afterEvaluate to ensure the configuration is populated.
+            Set<String> apis = conjureIrConfiguration.getAllDependencies().stream()
+                    .map(Dependency::getName)
+                    .collect(ImmutableSet.toImmutableSet());
+
+            Sets.SetView<String> missingProjects =
+                    Sets.difference(apis, project.getChildProjects().keySet());
+            if (!missingProjects.isEmpty()) {
+                throw new RuntimeException(
+                        String.format("Discovered dependencies %s without corresponding subprojects.", missingProjects));
+            }
+            Sets.SetView<String> missingApis =
+                    Sets.difference(project.getChildProjects().keySet(), apis);
+            if (!missingApis.isEmpty()) {
+                throw new RuntimeException(
+                        String.format("Discovered subprojects %s without corresponding dependencies.", missingApis));
+            }
+        });
     }
 
     private static void configureDependencies(Project project, ConjureExtension extension) {

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -173,7 +173,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                             + difference);
         }
 
-        project.afterEvaluate(_p -> configs.forEach((suffix, config) -> setupDerivedJavaProject(
+        configs.forEach((suffix, config) -> setupDerivedJavaProject(
                 suffix,
                 project,
                 optionsSupplier,
@@ -181,7 +181,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                 compileIrTask,
                 productDependencyExt,
                 extractJavaTask,
-                config)));
+                config));
     }
 
     private static Project setupDerivedJavaProject(
@@ -284,23 +284,32 @@ public final class ConjurePlugin implements Plugin<Project> {
     }
 
     private static void setupRetrofitProject(Project project, Supplier<GeneratorOptions> optionsSupplier) {
-        boolean useJakarta = Dependencies.isJakartaPackages(optionsSupplier.get());
         project.getDependencies().add("api", "com.google.guava:guava");
         project.getDependencies().add("api", "com.squareup.retrofit2:retrofit");
         project.getDependencies()
-                .add(
+                .addProvider(
                         "compileOnly",
-                        useJakarta ? Dependencies.ANNOTATION_API_JAKARTA : Dependencies.ANNOTATION_API_JAVAX);
+                        project.getProviders()
+                                .provider(() -> Dependencies.isJakartaPackages(optionsSupplier.get())
+                                        ? Dependencies.ANNOTATION_API_JAKARTA
+                                        : Dependencies.ANNOTATION_API_JAVAX));
     }
 
     private static void setupJerseyProject(Project project, Supplier<GeneratorOptions> optionsSupplier) {
-        boolean useJakarta = Dependencies.isJakartaPackages(optionsSupplier.get());
         project.getDependencies()
-                .add("api", useJakarta ? Dependencies.JAXRS_API_JAKARTA : Dependencies.JAXRS_API_JAVAX);
+                .addProvider(
+                        "api",
+                        project.getProviders()
+                                .provider(() -> Dependencies.isJakartaPackages(optionsSupplier.get())
+                                        ? Dependencies.JAXRS_API_JAKARTA
+                                        : Dependencies.JAXRS_API_JAVAX));
         project.getDependencies()
-                .add(
+                .addProvider(
                         "compileOnly",
-                        useJakarta ? Dependencies.ANNOTATION_API_JAKARTA : Dependencies.ANNOTATION_API_JAVAX);
+                        project.getProviders()
+                                .provider(() -> Dependencies.isJakartaPackages(optionsSupplier.get())
+                                        ? Dependencies.ANNOTATION_API_JAKARTA
+                                        : Dependencies.ANNOTATION_API_JAVAX));
     }
 
     private static void setupUndertowProject(Project project, Supplier<GeneratorOptions> _optionsSupplier) {


### PR DESCRIPTION
## Before this PR
Previously, this was added because wiring up dependencies for some subprojects requires reading flags from a ConjureExtension, and those values are not available until after the root conjure project is fully evaluated.

The afterEvaluate causes some problems for downstream repositories that try to do things at evaluation time (such as set up task dependencies for tasks that are created by the conjure plugin's application to the root api project); in those cases, users were being forced to put _their_ code into an afterEvaluate block as well, which is not ideal.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Dependencies for subprojects are now added via an `addProvider` instead which defers execution of the code that adds the dependencies until the project is actually configured, by which time the extension values have been populated.
==COMMIT_MSG==

## Possible downsides?
In the case of ConjureJavaLocalCodegenPlugin, the provider sometimes returns `null` (e.g. when reading a value from the ConjureExtension evaluates falsey); this isn't documented in the Gradle API literature, but seems to do the correct thing, which is to just not alter the configuration's dependency set. But maybe it's bad?

