### PR TITLE
Revert "remove afterEvaluate in some places (#1246)"

### DIFF
--- a/changelog/5.40.0/pr-1246.v2.yml
+++ b/changelog/5.40.0/pr-1246.v2.yml
@@ -1,7 +1,0 @@
-type: improvement
-improvement:
-  description: Dependencies for subprojects are now added via an `addProvider` instead
-    which defers execution of the code that adds the dependencies until the project
-    is actually configured, by which time the extension values have been populated.
-  links:
-  - https://github.com/palantir/gradle-conjure/pull/1246

--- a/changelog/@unreleased/pr-1248.v2.yml
+++ b/changelog/@unreleased/pr-1248.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Revert "remove afterEvaluate in some places (#1246)"
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/1248

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -173,7 +173,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                             + difference);
         }
 
-        configs.forEach((suffix, config) -> setupDerivedJavaProject(
+        project.afterEvaluate(_p -> configs.forEach((suffix, config) -> setupDerivedJavaProject(
                 suffix,
                 project,
                 optionsSupplier,
@@ -181,7 +181,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                 compileIrTask,
                 productDependencyExt,
                 extractJavaTask,
-                config));
+                config)));
     }
 
     private static Project setupDerivedJavaProject(
@@ -284,32 +284,23 @@ public final class ConjurePlugin implements Plugin<Project> {
     }
 
     private static void setupRetrofitProject(Project project, Supplier<GeneratorOptions> optionsSupplier) {
+        boolean useJakarta = Dependencies.isJakartaPackages(optionsSupplier.get());
         project.getDependencies().add("api", "com.google.guava:guava");
         project.getDependencies().add("api", "com.squareup.retrofit2:retrofit");
         project.getDependencies()
-                .addProvider(
+                .add(
                         "compileOnly",
-                        project.getProviders()
-                                .provider(() -> Dependencies.isJakartaPackages(optionsSupplier.get())
-                                        ? Dependencies.ANNOTATION_API_JAKARTA
-                                        : Dependencies.ANNOTATION_API_JAVAX));
+                        useJakarta ? Dependencies.ANNOTATION_API_JAKARTA : Dependencies.ANNOTATION_API_JAVAX);
     }
 
     private static void setupJerseyProject(Project project, Supplier<GeneratorOptions> optionsSupplier) {
+        boolean useJakarta = Dependencies.isJakartaPackages(optionsSupplier.get());
         project.getDependencies()
-                .addProvider(
-                        "api",
-                        project.getProviders()
-                                .provider(() -> Dependencies.isJakartaPackages(optionsSupplier.get())
-                                        ? Dependencies.JAXRS_API_JAKARTA
-                                        : Dependencies.JAXRS_API_JAVAX));
+                .add("api", useJakarta ? Dependencies.JAXRS_API_JAKARTA : Dependencies.JAXRS_API_JAVAX);
         project.getDependencies()
-                .addProvider(
+                .add(
                         "compileOnly",
-                        project.getProviders()
-                                .provider(() -> Dependencies.isJakartaPackages(optionsSupplier.get())
-                                        ? Dependencies.ANNOTATION_API_JAKARTA
-                                        : Dependencies.ANNOTATION_API_JAVAX));
+                        useJakarta ? Dependencies.ANNOTATION_API_JAKARTA : Dependencies.ANNOTATION_API_JAVAX);
     }
 
     private static void setupUndertowProject(Project project, Supplier<GeneratorOptions> _optionsSupplier) {


### PR DESCRIPTION
This reverts commit ef88312c88308a6d59e9d35b6faefcd6f309902a.

==COMMIT_MSG==
Revert "remove afterEvaluate in some places (#1246)"

After this change, gradle-conjure was still incorrectly seting the jaxrs dependencies for jersey/retrofit projects, even though the code generation with jakarta is correct, which causes a compile failure.

This reverts commit ef88312c88308a6d59e9d35b6faefcd6f309902a.
==COMMIT_MSG==