### PR TITLE
set the jakartaPackages flag via a gradle property

### DIFF
--- a/gradle-conjure-api/src/main/java/com/palantir/gradle/conjure/api/ConjureExtension.java
+++ b/gradle-conjure-api/src/main/java/com/palantir/gradle/conjure/api/ConjureExtension.java
@@ -20,6 +20,7 @@ import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import java.util.HashMap;
 import java.util.Map;
+import org.gradle.api.Project;
 
 public class ConjureExtension {
 
@@ -31,12 +32,16 @@ public class ConjureExtension {
     private final GeneratorOptions pythonOptions = new GeneratorOptions();
     private final Map<String, GeneratorOptions> genericOptions = new HashMap<>();
 
-    public ConjureExtension() {
+    public ConjureExtension(Project project) {
         // Projects using sufficiently new gradle-conjure have jetbrains-annotations
         // added by default. Conjure generators ignore unknown flags and will not be
         // impacted if generators have not been updated.
         // See https://github.com/palantir/conjure-java/pull/1884
         javaOptions.addFlag("jetbrainsContractAnnotations");
+
+        if (Boolean.parseBoolean((String) project.findProperty("conjure.java.jakartaPackages"))) {
+            javaOptions.addFlag("jakartaPackages");
+        }
     }
 
     public final void typescript(

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureBasePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureBasePlugin.java
@@ -59,7 +59,8 @@ public final class ConjureBasePlugin implements Plugin<Project> {
                         ConjureProductDependenciesExtension.EXTENSION_NAME,
                         ConjureProductDependenciesExtension.class,
                         project);
-        conjureExtension = project.getExtensions().create(ConjureExtension.EXTENSION_NAME, ConjureExtension.class);
+        conjureExtension =
+                project.getExtensions().create(ConjureExtension.EXTENSION_NAME, ConjureExtension.class, project);
         SourceDirectorySet conjureSourceSet = createConjureSourceSet(project);
         TaskProvider<Copy> copyConjureSourcesTask = createCopyConjureSourceTask(project, conjureSourceSet);
         compileIrProvider =

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -53,7 +53,7 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
         project.getPlugins().apply(JavaBasePlugin.class);
 
         ConjureExtension extension =
-                project.getExtensions().create(ConjureExtension.EXTENSION_NAME, ConjureExtension.class);
+                project.getExtensions().create(ConjureExtension.EXTENSION_NAME, ConjureExtension.class, project);
 
         Configuration conjureIrConfiguration = project.getConfigurations().create(CONJURE_CONFIGURATION);
         TaskProvider<Copy> extractConjureIr = project.getTasks().register("extractConjureIr", Copy.class, task -> {
@@ -79,12 +79,11 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
             createGenerateTask(subproject, extension, extractJavaTask, extractConjureIr);
         });
 
+        project.getChildProjects().forEach((_name, subproject) -> {
+            configureDependencies(subproject, extension);
+        });
+
         project.afterEvaluate(_p -> {
-            project.getChildProjects().forEach((_name, subproject) -> {
-                // Configure subproject dependencies in after-evaluate to ensure
-                // extension the has been evaluated.
-                configureDependencies(subproject, extension);
-            });
             // Validating that each subproject has a corresponding definition and vice versa.
             // We do this in afterEvaluate to ensure the configuration is populated.
             Set<String> apis = conjureIrConfiguration.getAllDependencies().stream()

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
@@ -57,7 +57,7 @@ public final class ConjureLocalPlugin implements Plugin<Project> {
                 project.getConfigurations().maybeCreate(ConjurePlugin.CONJURE_GENERATORS_CONFIGURATION_NAME);
 
         ConjureExtension extension =
-                project.getExtensions().create(ConjureExtension.EXTENSION_NAME, ConjureExtension.class);
+                project.getExtensions().create(ConjureExtension.EXTENSION_NAME, ConjureExtension.class, project);
 
         TaskProvider<Task> generateConjure = project.getTasks().register("generateConjure", task -> {
             task.setDescription("Generates code for all requested languages (for which there is a subproject) "

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -173,7 +173,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                             + difference);
         }
 
-        project.afterEvaluate(_p -> configs.forEach((suffix, config) -> setupDerivedJavaProject(
+        configs.forEach((suffix, config) -> setupDerivedJavaProject(
                 suffix,
                 project,
                 optionsSupplier,
@@ -181,7 +181,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                 compileIrTask,
                 productDependencyExt,
                 extractJavaTask,
-                config)));
+                config));
     }
 
     private static Project setupDerivedJavaProject(

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -523,13 +523,9 @@ class ConjurePluginTest extends IntegrationSpec {
             }
         }
         """.stripIndent()
-        file('api/build.gradle') << '''
-        conjure {
-            java {
-                jakartaPackages = true
-            }
-        }
-        '''.stripIndent()
+        createFile('gradle.properties') << """
+        conjure.java.jakartaPackages=true
+        """.stripIndent()
         updateSettings(prefix)
 
         when:


### PR DESCRIPTION
## Before this PR
This flag was previously set thusly in a build script:
```
conjure {
    java {
        jakartaPackages = true
    }
}
```

While that's still possible, it potentially causes problems when configuring subprojects due to evaluation order; the flag's value is not populated within the extension object until some time _after_ the plugin application finishes, which results in incorrect dependencies getting added to some subprojects when they are set up in `ConjurePlugin` and similar plugin applications.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Adding a gradle property `conjure.java.jakartaPackages=true` will cause the value to be set eagerly on the extension object such that it will always exist at the time the `ConjurePlugin`'s application logic runs, and so should have the value set correctly at the time subproject dependencies are added.
==COMMIT_MSG==

## Possible downsides?
It's an extra level of annoyance to have to set this e.g. via a `gradle.properties` file.
