### PR TITLE
fix the pattern used to parse local conjure def names

### DIFF
--- a/changelog/@unreleased/pr-1354.v2.yml
+++ b/changelog/@unreleased/pr-1354.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Support packages with commit-based versions for conjure local generation
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/1354

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalGenerateGenericTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalGenerateGenericTask.java
@@ -27,7 +27,7 @@ import java.util.regex.Pattern;
 public abstract class ConjureLocalGenerateGenericTask extends ConjureLocalGenerateTask {
 
     private static final Pattern PATTERN =
-            Pattern.compile("^(.*)-([0-9]+\\.[0-9]+\\.[0-9]+(?:-rc[0-9]+)?(?:-g[a-f0-9]+)?)(?:.conjure)?.json$");
+            Pattern.compile("^(.*)-([0-9]+\\.[0-9]+\\.[0-9]+(?:-rc[0-9]+)?(?:-[1-9][0-9]*-g[a-f0-9]+)?)(?:.conjure)?.json$");
 
     @Override
     protected final Map<String, Supplier<Object>> requiredOptions(File irFile) {

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalGenerateGenericTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalGenerateGenericTask.java
@@ -27,7 +27,7 @@ import java.util.regex.Pattern;
 
 public abstract class ConjureLocalGenerateGenericTask extends ConjureLocalGenerateTask {
 
-    private static final Pattern PATTERN = Pattern.compile("^([^.]+)-(.+?)(?:\\.conjure)?\\.json$");
+    private static final Pattern PATTERN = Pattern.compile("^([^.]+)-(.+?)(\\.conjure)?\\.json$");
 
     @Override
     protected final Map<String, Supplier<Object>> requiredOptions(File irFile) {
@@ -37,7 +37,7 @@ public abstract class ConjureLocalGenerateGenericTask extends ConjureLocalGenera
     @VisibleForTesting
     static Map<String, Supplier<Object>> resolveProductMetadata(String productName) {
         Matcher matcher = PATTERN.matcher(productName);
-        if (!matcher.matches() || matcher.groupCount() != 2) {
+        if (!matcher.matches() || matcher.groupCount() < 2) {
             throw new RuntimeException(String.format("Unable to parse conjure dependency name %s", productName));
         }
         String irName = matcher.group(1);

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalGenerateGenericTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalGenerateGenericTask.java
@@ -18,6 +18,7 @@ package com.palantir.gradle.conjure;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
+import com.palantir.sls.versions.OrderableSlsVersion;
 import java.io.File;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -26,8 +27,7 @@ import java.util.regex.Pattern;
 
 public abstract class ConjureLocalGenerateGenericTask extends ConjureLocalGenerateTask {
 
-    private static final Pattern PATTERN =
-            Pattern.compile("^(.*)-([0-9]+\\.[0-9]+\\.[0-9]+(?:-rc[0-9]+)?(?:-[1-9][0-9]*-g[a-f0-9]+)?)(?:.conjure)?.json$");
+    private static final Pattern PATTERN = Pattern.compile("^([^.]+)-(.+?)(?:\\.conjure)?\\.json$");
 
     @Override
     protected final Map<String, Supplier<Object>> requiredOptions(File irFile) {
@@ -40,9 +40,15 @@ public abstract class ConjureLocalGenerateGenericTask extends ConjureLocalGenera
         if (!matcher.matches() || matcher.groupCount() != 2) {
             throw new RuntimeException(String.format("Unable to parse conjure dependency name %s", productName));
         }
-
         String irName = matcher.group(1);
         String irVersion = matcher.group(2);
+
+        if (!OrderableSlsVersion.check(irVersion)) {
+            throw new RuntimeException(String.format(
+                    "Unable to parse orderable SLS version from conjure dependency name %s, version %s",
+                    productName, irVersion));
+        }
+
         return ImmutableMap.of("productName", () -> irName, "productVersion", () -> irVersion);
     }
 }

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalGenerateGenericTaskTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalGenerateGenericTaskTest.groovy
@@ -31,11 +31,10 @@ class ConjureLocalGenerateGenericTaskTest extends Specification {
         where:
         fileName                           | expectedProductName | expectedProductVersion
         'foo-1.0.0.json'                   | "foo"               | '1.0.0'
-        "foo-baz-1.0.0.json"               | "foo-baz"           | "1.0.0"
+        "foo-baz-2-1.0.0.json"             | "foo-baz-2"         | "1.0.0"
         "foo-1.0.0.conjure.json"           | "foo"               | "1.0.0"
         "foo-1.0.0-rc1.conjure.json"       | "foo"               | "1.0.0-rc1"
-        "foo-1.0.0-gabcd.conjure.json"     | "foo"               | "1.0.0-gabcd"
-        "foo-1.0.0-rc1-gabcd.conjure.json" | "foo"               | "1.0.0-rc1-gabcd"
+        "foo-1.0.0-12-gabcd.conjure.json"  | "foo"               | "1.0.0-12-gabcd"
     }
 
     def "fails to parse invalid names"() {


### PR DESCRIPTION
to allow non-tagged/non-rc'd builds from commits

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

Would fail to parse locally published packages with commit-based versions, like `test-api-0.123.0-123-g1a2c3d.conjure.json`

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Support packages with commit-based versions for conjure local generation
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

