### PR TITLE
Gradle 8 fixes

### DIFF
--- a/changelog/@unreleased/pr-1401.v2.yml
+++ b/changelog/@unreleased/pr-1401.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Set up correct dependencies for Gradle 8.
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/1401

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -132,7 +132,6 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
             TaskProvider<ExtractExecutableTask> extractJavaTask,
             TaskProvider<Copy> extractConjureIr) {
         ConjurePlugin.ignoreFromCheckUnusedDependencies(project);
-        ConjurePlugin.addGeneratedToMainSourceSet(project);
 
         TaskProvider<WriteGitignoreTask> generateGitIgnore = ConjurePlugin.createWriteGitignoreTask(
                 project, "gitignoreConjure", project.getProjectDir(), ConjurePlugin.JAVA_GITIGNORE_CONTENTS);
@@ -164,8 +163,12 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
                     task.dependsOn(extractJavaTask, extractConjureIr, generateGitIgnore);
                 });
 
+        ConjurePlugin.addGeneratedToMainSourceSet(project, generateJava);
+
         project.getTasks().named("compileJava").configure(compileJava -> compileJava.dependsOn(generateJava));
         ConjurePlugin.applyDependencyForIdeTasks(project, generateJava);
+        ConjurePlugin.configureIdeGeneratedSources(
+                project, generateJava.flatMap(ConjureJavaLocalGeneratorTask::getOutputDirectory));
     }
 
     /**

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -85,7 +85,7 @@ public final class ConjurePlugin implements Plugin<Project> {
     static final ImmutableSet<String> JAVA_PROJECT_SUFFIXES = ImmutableSet.of(
             JAVA_DIALOGUE_SUFFIX, JAVA_OBJECTS_SUFFIX, JAVA_JERSEY_SUFFIX, JAVA_RETROFIT_SUFFIX, JAVA_UNDERTOW_SUFFIX);
     static final String JAVA_GENERATED_SOURCE_DIRNAME = "src/generated/java";
-    static final String JAVA_GITIGNORE_CONTENTS = "/src/generated/java/\n";
+    static final String JAVA_GITIGNORE_CONTENTS = "/build/generated/\n";
 
     private static final ImmutableSet<String> FIRST_CLASS_GENERATOR_PROJECT_NAMES = ImmutableSet.<String>builder()
             .addAll(JAVA_PROJECT_SUFFIXES)
@@ -637,6 +637,8 @@ public final class ConjurePlugin implements Plugin<Project> {
             IdeaModule module = plugin.getModel().getModule();
 
             // module.getSourceDirs / getGeneratedSourceDirs could be an immutable set, so defensively copy
+            module.setSourceDirs(mutableSetWithExtraEntry(
+                    module.getSourceDirs(), generated.get().getAsFile()));
             module.setGeneratedSourceDirs(mutableSetWithExtraEntry(
                     module.getGeneratedSourceDirs(), generated.get().getAsFile()));
         });

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -29,6 +29,7 @@ import com.palantir.gradle.utils.environmentvariables.EnvironmentVariables;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -49,11 +50,13 @@ import org.gradle.api.Task;
 import org.gradle.api.UnknownTaskException;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.file.Directory;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaLibraryPlugin;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Delete;
 import org.gradle.api.tasks.Exec;
 import org.gradle.api.tasks.TaskOutputs;
@@ -212,7 +215,8 @@ public final class ConjurePlugin implements Plugin<Project> {
         return parentProject.project(derivedProjectPath(parentProject, projectName), subproj -> {
             subproj.getPluginManager().apply(JavaLibraryPlugin.class);
             ignoreFromCheckUnusedDependencies(subproj);
-            addGeneratedToMainSourceSet(subproj);
+            TaskProvider<WriteGitignoreTask> writeGitignoreTask = createWriteGitignoreTask(
+                    subproj, "gitignoreConjure" + upperSuffix, subproj.getProjectDir(), JAVA_GITIGNORE_CONTENTS);
             TaskProvider<ConjureGeneratorTask> conjureGeneratorTask = parentProject
                     .getTasks()
                     .register("compileConjure" + upperSuffix, ConjureGeneratorTask.class, task -> {
@@ -221,18 +225,18 @@ public final class ConjurePlugin implements Plugin<Project> {
                         task.setGroup(TASK_GROUP);
                         task.getExecutablePath().set(extractJavaTask.flatMap(ExtractExecutableTask::getExecutable));
                         task.setOptions(() -> optionsSupplier.get().addFlag(projectSuffix));
-                        task.getOutputDirectory().set(subproj.file(JAVA_GENERATED_SOURCE_DIRNAME));
+                        task.getOutputDirectory()
+                                .set(subproj.getLayout()
+                                        .getBuildDirectory()
+                                        .dir("generated/sources/conjure-" + projectSuffix + "/main/java"));
                         task.setSource(compileIrTask);
-
-                        task.dependsOn(createWriteGitignoreTask(
-                                subproj,
-                                "gitignoreConjure" + upperSuffix,
-                                subproj.getProjectDir(),
-                                JAVA_GITIGNORE_CONTENTS));
-                        task.dependsOn(extractJavaTask, compileIrTask);
+                        task.dependsOn(extractJavaTask, compileIrTask, writeGitignoreTask);
                     });
+            addGeneratedToMainSourceSet(subproj, conjureGeneratorTask);
             subproj.getTasks().named("compileJava").configure(t -> t.dependsOn(conjureGeneratorTask));
             applyDependencyForIdeTasks(subproj, conjureGeneratorTask);
+            ConjurePlugin.configureIdeGeneratedSources(
+                    subproj, conjureGeneratorTask.flatMap(ConjureGeneratorTask::getOutputDirectory));
             compileConjure.configure(t -> t.dependsOn(conjureGeneratorTask));
 
             registerClean(parentProject, conjureGeneratorTask);
@@ -602,14 +606,14 @@ public final class ConjurePlugin implements Plugin<Project> {
 
     // TODO(fwindheuser): Replace 'JavaPluginConvention'  with 'JavaPluginExtension' after dropping Gradle 6 support.
     @SuppressWarnings("deprecation")
-    static void addGeneratedToMainSourceSet(Project subproj) {
+    static void addGeneratedToMainSourceSet(Project subproj, TaskProvider<?> conjureGeneratorTask) {
         org.gradle.api.plugins.JavaPluginConvention javaPlugin =
                 subproj.getConvention().findPlugin(org.gradle.api.plugins.JavaPluginConvention.class);
-        javaPlugin.getSourceSets().getByName("main").getJava().srcDir(subproj.files(JAVA_GENERATED_SOURCE_DIRNAME));
+        javaPlugin.getSourceSets().getByName("main").getJava().srcDir(conjureGeneratorTask);
     }
 
     static void applyDependencyForIdeTasks(Project project, TaskProvider<?> compileConjure) {
-        project.getPlugins().withType(IdeaPlugin.class, plugin -> {
+        project.getPlugins().withType(IdeaPlugin.class, _plugin -> {
             // root project does not have the ideaModule task.  There is unfortunately no
             // safe way to check for existence with the task avoidance APIs
             try {
@@ -617,15 +621,6 @@ public final class ConjurePlugin implements Plugin<Project> {
             } catch (UnknownTaskException e) {
                 project.getLogger().debug("Project does not have ideaModule task.", e);
             }
-
-            IdeaModule module = plugin.getModel().getModule();
-
-            // module.getSourceDirs / getGeneratedSourceDirs could be an immutable set, so defensively copy
-            module.setSourceDirs(
-                    mutableSetWithExtraEntry(module.getSourceDirs(), project.file(JAVA_GENERATED_SOURCE_DIRNAME)));
-
-            module.setGeneratedSourceDirs(mutableSetWithExtraEntry(
-                    module.getGeneratedSourceDirs(), project.file(JAVA_GENERATED_SOURCE_DIRNAME)));
         });
 
         project.getPlugins().withType(EclipsePlugin.class, _plugin -> {
@@ -634,6 +629,22 @@ public final class ConjurePlugin implements Plugin<Project> {
             } catch (UnknownTaskException e) {
                 // eclipseClasspath is not always registered
             }
+        });
+    }
+
+    static void configureIdeGeneratedSources(Project project, Provider<Directory> generated) {
+        project.getPlugins().withType(IdeaPlugin.class, plugin -> {
+            IdeaModule module = plugin.getModel().getModule();
+
+            // module.getSourceDirs / getGeneratedSourceDirs could be an immutable set, so defensively copy
+            module.setGeneratedSourceDirs(mutableSetWithExtraEntry(
+                    module.getGeneratedSourceDirs(), generated.get().getAsFile()));
+        });
+
+        project.getPlugins().withType(EclipsePlugin.class, _plugin -> {
+            String generatedSourceDirectory = asPath(project.getLayout().getProjectDirectory())
+                    .relativize(asPath(generated))
+                    .toString();
             project.getExtensions().configure(EclipseModel.class, eclipseModel -> {
                 eclipseModel.classpath(classpath -> {
                     classpath.file(file -> {
@@ -641,7 +652,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                             cp.getEntries().stream()
                                     .filter(cpe -> cpe instanceof SourceFolder)
                                     .map(cpe -> (SourceFolder) cpe)
-                                    .filter(sf -> sf.getPath().equals(JAVA_GENERATED_SOURCE_DIRNAME))
+                                    .filter(sf -> sf.getPath().equals(generatedSourceDirectory))
                                     .findFirst()
                                     .ifPresent(sf -> {
                                         Map<String, Object> attributes = sf.getEntryAttributes();
@@ -655,6 +666,14 @@ public final class ConjurePlugin implements Plugin<Project> {
         });
     }
 
+    private static Path asPath(Directory directory) {
+        return directory.getAsFile().toPath();
+    }
+
+    private static Path asPath(Provider<Directory> directory) {
+        return asPath(directory.get());
+    }
+
     private static <T> Set<T> mutableSetWithExtraEntry(Set<T> set, T extraItem) {
         Set<T> newSet = new LinkedHashSet<>(set);
         newSet.add(extraItem);
@@ -663,12 +682,10 @@ public final class ConjurePlugin implements Plugin<Project> {
 
     static TaskProvider<WriteGitignoreTask> createWriteGitignoreTask(
             Project project, String taskName, File outputDir, String contents) {
-        TaskProvider<WriteGitignoreTask> writeGitignoreTask = project.getTasks()
-                .register(taskName, WriteGitignoreTask.class, task -> {
-                    task.setOutputDirectory(outputDir);
-                    task.setContents(contents);
-                });
-        return writeGitignoreTask;
+        return project.getTasks().register(taskName, WriteGitignoreTask.class, task -> {
+            task.setOutputDirectory(outputDir);
+            task.setContents(contents);
+        });
     }
 
     private static Supplier<GeneratorOptions> immutableOptionsSupplier(Supplier<GeneratorOptions> supplier) {

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureGeneratorTaskTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureGeneratorTaskTest.groovy
@@ -79,7 +79,7 @@ class ConjureGeneratorTaskTest extends IntegrationSpec {
         result.wasExecuted(':api:compileIr')
 
         // java
-        fileExists('api/api-objects/src/generated/java/test/test/api/StringExample.java')
+        fileExists('api/api-objects/build/generated/sources/conjure-objects/main/java/test/test/api/StringExample.java')
     }
 
     def "cleans up old files"() {
@@ -106,8 +106,8 @@ class ConjureGeneratorTaskTest extends IntegrationSpec {
         result2.wasExecuted(':api:compileIr')
 
         // java
-        !fileExists('api/api-objects/src/generated/java/test/test/api/StringExample.java')
-        fileExists('api/api-objects/src/generated/java/test/test/api/NewStringExample.java')
+        !fileExists('api/api-objects/build/generated/sources/conjure-objects/main/java/test/test/api/StringExample.java')
+        fileExists('api/api-objects/build/generated/sources/conjure-objects/main/java/test/test/api/NewStringExample.java')
     }
 
     def 'when a file has errors the error is reported in the exception'() {

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -125,10 +125,10 @@ class ConjurePluginTest extends IntegrationSpec {
         result.wasExecuted(':api:compileIr')
 
         // java
-        fileExists(prefixPath(prefix, 'api-objects/src/generated/java/test/test/api/StringExample.java'))
-        file(prefixPath(prefix, 'api-objects/src/generated/java/test/test/api/StringExample.java')).text.contains('ignoreUnknown')
+        fileExists(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/main/java/test/test/api/StringExample.java'))
+        file(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/main/java/test/test/api/StringExample.java')).text.contains('ignoreUnknown')
         fileExists(prefixPath(prefix, 'api-objects/.gitignore'))
-        file(prefixPath(prefix, 'api-objects/.gitignore')).readLines() == ['/src/generated/java/']
+        file(prefixPath(prefix, 'api-objects/.gitignore')).readLines() == ['/build/generated/sources/conjure-objects/main/']
 
         // typescript
         fileExists(prefixPath(prefix, 'api-typescript/src/api/index.ts'))
@@ -167,7 +167,7 @@ class ConjurePluginTest extends IntegrationSpec {
         result.wasExecuted(prefixProject(prefix, 'api-dialogue:compileJava'))
         result.wasExecuted(':api:compileConjureDialogue')
 
-        fileExists(prefixPath(prefix, 'api-objects/src/generated/java/test/test/api/StringExample.java'))
+        fileExists(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/main/java/test/test/api/StringExample.java'))
         fileExists(prefixPath(prefix, 'api-objects/.gitignore'))
 
         where:
@@ -228,7 +228,7 @@ class ConjurePluginTest extends IntegrationSpec {
         result.wasExecuted(prefixProject(prefix, 'api-jersey:compileJava'))
         result.wasExecuted(':api:compileConjureJersey')
 
-        fileExists(prefixPath(prefix, 'api-objects/src/generated/java/test/test/api/StringExample.java'))
+        fileExists(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/main/java/test/test/api/StringExample.java'))
         fileExists(prefixPath(prefix, 'api-objects/.gitignore'))
 
         where:
@@ -237,12 +237,21 @@ class ConjurePluginTest extends IntegrationSpec {
         'peer'     | ''
     }
 
-    def 'clean cleans up src/generated/java: #location'() {
+    def 'clean cleans up build/generated/sources/conjure-*/main/java: #location'() {
         setup:
         updateSettings(prefix)
 
         when:
         runTasksSuccessfully('compileJava')
+
+        then:
+        fileExists(prefixPath(prefix, 'api-jersey/build/generated/sources/conjure-jersey/main/java'))
+        fileExists(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/main/java'))
+        fileExists(prefixPath(prefix, 'api-retrofit/build/generated/sources/conjure-retrofit/main/java'))
+        fileExists(prefixPath(prefix, 'api-undertow/build/generated/sources/conjure-undertow/main/java'))
+        fileExists(prefixPath(prefix, 'api-dialogue/build/generated/sources/conjure-dialogue/main/java'))
+
+        when:
         ExecutionResult result = runTasksSuccessfully('clean')
 
         then:
@@ -252,11 +261,11 @@ class ConjurePluginTest extends IntegrationSpec {
         result.wasExecuted(':api:cleanCompileConjureUndertow')
         result.wasExecuted(':api:cleanCompileConjureDialogue')
 
-        !fileExists(prefixPath(prefix, 'api-jersey/src/generated/java'))
-        !fileExists(prefixPath(prefix, 'api-objects/src/generated/java'))
-        !fileExists(prefixPath(prefix, 'api-retrofit/src/generated/java'))
-        !fileExists(prefixPath(prefix, 'api-undertow/src/generated/java'))
-        !fileExists(prefixPath(prefix, 'api-dialogue/src/generated/java'))
+        !fileExists(prefixPath(prefix, 'api-jersey/build/generated/sources/conjure-jersey/main/java'))
+        !fileExists(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/main/java'))
+        !fileExists(prefixPath(prefix, 'api-retrofit/build/generated/sources/conjure-retrofit/main/java'))
+        !fileExists(prefixPath(prefix, 'api-undertow/build/generated/sources/conjure-undertow/main/java'))
+        !fileExists(prefixPath(prefix, 'api-dialogue/build/generated/sources/conjure-dialogue/main/java'))
 
         where:
         location   | prefix
@@ -425,11 +434,11 @@ class ConjurePluginTest extends IntegrationSpec {
         fileExists('api/build/conjure/conjure.yml')
 
         // java
-        file(prefixPath(prefix, 'api-jersey/src/generated/java/test/api/service/TestServiceFoo2.java')).text.contains(
+        file(prefixPath(prefix, 'api-jersey/build/generated/sources/conjure-jersey/main/java/test/api/service/TestServiceFoo2.java')).text.contains(
                 'import test.api.internal.InternalImport;')
-        file(prefixPath(prefix, 'api-retrofit/src/generated/java/test/api/service/TestServiceFoo2Retrofit.java')).text.contains(
+        file(prefixPath(prefix, 'api-retrofit/build/generated/sources/conjure-retrofit/main/java/test/api/service/TestServiceFoo2Retrofit.java')).text.contains(
                 'import test.api.internal.InternalImport;')
-        fileExists(prefixPath(prefix, 'api-objects/src/generated/java/test/api/internal/InternalImport.java'))
+        fileExists(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/main/java/test/api/internal/InternalImport.java'))
 
         // typescript
         file(prefixPath(prefix, 'api-typescript/src/service/testServiceFoo2.ts')).text.contains(
@@ -461,8 +470,8 @@ class ConjurePluginTest extends IntegrationSpec {
         result.wasExecuted(':api:compileConjureObjects')
         !result.wasExecuted(':api:compileConjureJersey')
 
-        fileExists(prefixPath(prefix, 'api-objects/src/generated/java/test/test/api/StringExample.java'))
-        file(prefixPath(prefix, 'api-objects/src/generated/java/test/test/api/StringExample.java')).text.contains('ignoreUnknown')
+        fileExists(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/main/java/test/test/api/StringExample.java'))
+        file(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/main/java/test/test/api/StringExample.java')).text.contains('ignoreUnknown')
 
         where:
         location   | prefix
@@ -504,7 +513,7 @@ class ConjurePluginTest extends IntegrationSpec {
         ExecutionResult result = runTasksSuccessfully(':api:compileConjureUndertow')
 
         then:
-        fileExists(prefixPath(prefix, 'api-undertow/src/generated/java/test/test/api/UndertowTestServiceFoo.java'))
+        fileExists(prefixPath(prefix, 'api-undertow/build/generated/sources/conjure-undertow/main/java/test/test/api/UndertowTestServiceFoo.java'))
 
         where:
         location   | prefix
@@ -540,7 +549,7 @@ class ConjurePluginTest extends IntegrationSpec {
 
         then:
         result.success
-        String generated = prefixPath(prefix, 'api-jersey/src/generated/java/test/test/api/TestServiceFoo.java')
+        String generated = prefixPath(prefix, 'api-jersey/build/generated/sources/conjure-jersey/main/java/test/test/api/TestServiceFoo.java')
         fileExists(generated)
         File generatedFile = new File(projectDir, generated)
         generatedFile.text.contains("import jakarta.ws.rs.POST;")
@@ -709,7 +718,7 @@ class ConjurePluginTest extends IntegrationSpec {
 
         sourcesFolderUrls.size() == 2
         sourcesFolderUrls.contains('file://$MODULE_DIR$/some-extra-source-folder')
-        sourcesFolderUrls.contains('file://$MODULE_DIR$/src/generated/java')
+        sourcesFolderUrls.contains('file://$MODULE_DIR$/build/generated/sources/conjure-jersey/main/java')
     }
 
     def 'compileTypeScript is run on build for circle node 0'() {

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -128,7 +128,7 @@ class ConjurePluginTest extends IntegrationSpec {
         fileExists(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/main/java/test/test/api/StringExample.java'))
         file(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/main/java/test/test/api/StringExample.java')).text.contains('ignoreUnknown')
         fileExists(prefixPath(prefix, 'api-objects/.gitignore'))
-        file(prefixPath(prefix, 'api-objects/.gitignore')).readLines() == ['/build/generated/sources/conjure-objects/main/']
+        file(prefixPath(prefix, 'api-objects/.gitignore')).readLines() == ['/build/generated/']
 
         // typescript
         fileExists(prefixPath(prefix, 'api-typescript/src/api/index.ts'))


### PR DESCRIPTION
## Before this PR
The way `gradle-conjure` generates files means that it will run into [implicit dependency errors](https://docs.gradle.org/8.5/userguide/validation_problems.html#implicit_dependency). This was happening in [conjure](https://app.circleci.com/pipelines/github/palantir/conjure/2899/workflows/9fc8ef68-982f-4200-ab35-0f48b527887c/jobs/15251/steps).

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Set up correct dependencies for Gradle 8.
==COMMIT_MSG==

Key points:
* Instead of using a static directory, use the output of the generator task for the source set
* Set the output to be different for each generator task (java):
  * so instead of `src/generated/java`, we have `build/generated/sources/conjure-<type>/main/java`
  * This mirrors what gradle do with annotation processors: `build/generated/sources/annotationProcessor/java/main`
* Separate out the ide tasks so that running `./gradlew idea` or `./gradlew eclipse` depends on the umbrella task, but each subproject task 

## Possible downsides?
Hard to migrate python/typescript/other sources, as I don't know how they are consumed and that would be a break. In fairness the existing code had set up idea to do the wrong thing to them *anyway* but I imagine people will want to keep stuff in source. This *may* not fix us for the implicit dependency if we're running into the python/ts errors in 

