### PR TITLE
Follow conventions for generated directory

### DIFF
--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
@@ -112,7 +112,7 @@ public final class ConjureLocalPlugin implements Plugin<Project> {
                     task.getOutputDirectory()
                             .set(subproj.getLayout()
                                     .getBuildDirectory()
-                                    .dir("generated/sources/conjure-local-java/main/java"));
+                                    .dir("generated/sources/conjure-local-java/java/main"));
 
                     task.dependsOn(gitignoreConjureJava);
                     task.dependsOn(extractJavaTask);

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -228,7 +228,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                         task.getOutputDirectory()
                                 .set(subproj.getLayout()
                                         .getBuildDirectory()
-                                        .dir("generated/sources/conjure-" + projectSuffix + "/main/java"));
+                                        .dir("generated/sources/conjure-" + projectSuffix + "/java/main"));
                         task.setSource(compileIrTask);
                         task.dependsOn(extractJavaTask, compileIrTask, writeGitignoreTask);
                     });

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureGeneratorTaskTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureGeneratorTaskTest.groovy
@@ -79,7 +79,7 @@ class ConjureGeneratorTaskTest extends IntegrationSpec {
         result.wasExecuted(':api:compileIr')
 
         // java
-        fileExists('api/api-objects/build/generated/sources/conjure-objects/main/java/test/test/api/StringExample.java')
+        fileExists('api/api-objects/build/generated/sources/conjure-objects/java/main/test/test/api/StringExample.java')
     }
 
     def "cleans up old files"() {
@@ -106,8 +106,8 @@ class ConjureGeneratorTaskTest extends IntegrationSpec {
         result2.wasExecuted(':api:compileIr')
 
         // java
-        !fileExists('api/api-objects/build/generated/sources/conjure-objects/main/java/test/test/api/StringExample.java')
-        fileExists('api/api-objects/build/generated/sources/conjure-objects/main/java/test/test/api/NewStringExample.java')
+        !fileExists('api/api-objects/build/generated/sources/conjure-objects/java/main/test/test/api/StringExample.java')
+        fileExists('api/api-objects/build/generated/sources/conjure-objects/java/main/test/test/api/NewStringExample.java')
     }
 
     def 'when a file has errors the error is reported in the exception'() {

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -125,8 +125,8 @@ class ConjurePluginTest extends IntegrationSpec {
         result.wasExecuted(':api:compileIr')
 
         // java
-        fileExists(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/main/java/test/test/api/StringExample.java'))
-        file(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/main/java/test/test/api/StringExample.java')).text.contains('ignoreUnknown')
+        fileExists(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/java/main/test/test/api/StringExample.java'))
+        file(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/java/main/test/test/api/StringExample.java')).text.contains('ignoreUnknown')
         fileExists(prefixPath(prefix, 'api-objects/.gitignore'))
         file(prefixPath(prefix, 'api-objects/.gitignore')).readLines() == ['/build/generated/']
 
@@ -167,7 +167,7 @@ class ConjurePluginTest extends IntegrationSpec {
         result.wasExecuted(prefixProject(prefix, 'api-dialogue:compileJava'))
         result.wasExecuted(':api:compileConjureDialogue')
 
-        fileExists(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/main/java/test/test/api/StringExample.java'))
+        fileExists(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/java/main/test/test/api/StringExample.java'))
         fileExists(prefixPath(prefix, 'api-objects/.gitignore'))
 
         where:
@@ -228,7 +228,7 @@ class ConjurePluginTest extends IntegrationSpec {
         result.wasExecuted(prefixProject(prefix, 'api-jersey:compileJava'))
         result.wasExecuted(':api:compileConjureJersey')
 
-        fileExists(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/main/java/test/test/api/StringExample.java'))
+        fileExists(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/java/main/test/test/api/StringExample.java'))
         fileExists(prefixPath(prefix, 'api-objects/.gitignore'))
 
         where:
@@ -237,7 +237,7 @@ class ConjurePluginTest extends IntegrationSpec {
         'peer'     | ''
     }
 
-    def 'clean cleans up build/generated/sources/conjure-*/main/java: #location'() {
+    def 'clean cleans up build/generated/sources/conjure-*/java/main: #location'() {
         setup:
         updateSettings(prefix)
 
@@ -245,11 +245,11 @@ class ConjurePluginTest extends IntegrationSpec {
         runTasksSuccessfully('compileJava')
 
         then:
-        fileExists(prefixPath(prefix, 'api-jersey/build/generated/sources/conjure-jersey/main/java'))
-        fileExists(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/main/java'))
-        fileExists(prefixPath(prefix, 'api-retrofit/build/generated/sources/conjure-retrofit/main/java'))
-        fileExists(prefixPath(prefix, 'api-undertow/build/generated/sources/conjure-undertow/main/java'))
-        fileExists(prefixPath(prefix, 'api-dialogue/build/generated/sources/conjure-dialogue/main/java'))
+        fileExists(prefixPath(prefix, 'api-jersey/build/generated/sources/conjure-jersey/java/main'))
+        fileExists(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/java/main'))
+        fileExists(prefixPath(prefix, 'api-retrofit/build/generated/sources/conjure-retrofit/java/main'))
+        fileExists(prefixPath(prefix, 'api-undertow/build/generated/sources/conjure-undertow/java/main'))
+        fileExists(prefixPath(prefix, 'api-dialogue/build/generated/sources/conjure-dialogue/java/main'))
 
         when:
         ExecutionResult result = runTasksSuccessfully('clean')
@@ -261,11 +261,11 @@ class ConjurePluginTest extends IntegrationSpec {
         result.wasExecuted(':api:cleanCompileConjureUndertow')
         result.wasExecuted(':api:cleanCompileConjureDialogue')
 
-        !fileExists(prefixPath(prefix, 'api-jersey/build/generated/sources/conjure-jersey/main/java'))
-        !fileExists(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/main/java'))
-        !fileExists(prefixPath(prefix, 'api-retrofit/build/generated/sources/conjure-retrofit/main/java'))
-        !fileExists(prefixPath(prefix, 'api-undertow/build/generated/sources/conjure-undertow/main/java'))
-        !fileExists(prefixPath(prefix, 'api-dialogue/build/generated/sources/conjure-dialogue/main/java'))
+        !fileExists(prefixPath(prefix, 'api-jersey/build/generated/sources/conjure-jersey/java/main'))
+        !fileExists(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/java/main'))
+        !fileExists(prefixPath(prefix, 'api-retrofit/build/generated/sources/conjure-retrofit/java/main'))
+        !fileExists(prefixPath(prefix, 'api-undertow/build/generated/sources/conjure-undertow/java/main'))
+        !fileExists(prefixPath(prefix, 'api-dialogue/build/generated/sources/conjure-dialogue/java/main'))
 
         where:
         location   | prefix
@@ -434,11 +434,11 @@ class ConjurePluginTest extends IntegrationSpec {
         fileExists('api/build/conjure/conjure.yml')
 
         // java
-        file(prefixPath(prefix, 'api-jersey/build/generated/sources/conjure-jersey/main/java/test/api/service/TestServiceFoo2.java')).text.contains(
+        file(prefixPath(prefix, 'api-jersey/build/generated/sources/conjure-jersey/java/main/test/api/service/TestServiceFoo2.java')).text.contains(
                 'import test.api.internal.InternalImport;')
-        file(prefixPath(prefix, 'api-retrofit/build/generated/sources/conjure-retrofit/main/java/test/api/service/TestServiceFoo2Retrofit.java')).text.contains(
+        file(prefixPath(prefix, 'api-retrofit/build/generated/sources/conjure-retrofit/java/main/test/api/service/TestServiceFoo2Retrofit.java')).text.contains(
                 'import test.api.internal.InternalImport;')
-        fileExists(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/main/java/test/api/internal/InternalImport.java'))
+        fileExists(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/java/main/test/api/internal/InternalImport.java'))
 
         // typescript
         file(prefixPath(prefix, 'api-typescript/src/service/testServiceFoo2.ts')).text.contains(
@@ -470,8 +470,8 @@ class ConjurePluginTest extends IntegrationSpec {
         result.wasExecuted(':api:compileConjureObjects')
         !result.wasExecuted(':api:compileConjureJersey')
 
-        fileExists(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/main/java/test/test/api/StringExample.java'))
-        file(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/main/java/test/test/api/StringExample.java')).text.contains('ignoreUnknown')
+        fileExists(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/java/main/test/test/api/StringExample.java'))
+        file(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/java/main/test/test/api/StringExample.java')).text.contains('ignoreUnknown')
 
         where:
         location   | prefix
@@ -513,7 +513,7 @@ class ConjurePluginTest extends IntegrationSpec {
         ExecutionResult result = runTasksSuccessfully(':api:compileConjureUndertow')
 
         then:
-        fileExists(prefixPath(prefix, 'api-undertow/build/generated/sources/conjure-undertow/main/java/test/test/api/UndertowTestServiceFoo.java'))
+        fileExists(prefixPath(prefix, 'api-undertow/build/generated/sources/conjure-undertow/java/main/test/test/api/UndertowTestServiceFoo.java'))
 
         where:
         location   | prefix
@@ -549,7 +549,7 @@ class ConjurePluginTest extends IntegrationSpec {
 
         then:
         result.success
-        String generated = prefixPath(prefix, 'api-jersey/build/generated/sources/conjure-jersey/main/java/test/test/api/TestServiceFoo.java')
+        String generated = prefixPath(prefix, 'api-jersey/build/generated/sources/conjure-jersey/java/main/test/test/api/TestServiceFoo.java')
         fileExists(generated)
         File generatedFile = new File(projectDir, generated)
         generatedFile.text.contains("import jakarta.ws.rs.POST;")
@@ -718,7 +718,7 @@ class ConjurePluginTest extends IntegrationSpec {
 
         sourcesFolderUrls.size() == 2
         sourcesFolderUrls.contains('file://$MODULE_DIR$/some-extra-source-folder')
-        sourcesFolderUrls.contains('file://$MODULE_DIR$/build/generated/sources/conjure-jersey/main/java')
+        sourcesFolderUrls.contains('file://$MODULE_DIR$/build/generated/sources/conjure-jersey/java/main')
     }
 
     def 'compileTypeScript is run on build for circle node 0'() {


### PR DESCRIPTION
Small follow up from https://github.com/palantir/gradle-conjure/pull/1401.

## Before this PR

Annotation processors generate code into `build/generated/sources/<name>/java/main` but this plugin generates code into `build/generated/sources/<name>/main/java`.

While this is different than user-authored code, we should strive to follow the directory conventions for generated code.

## After this PR

This plugin generates code into `build/generated/sources/<name>/main/java`.
