### PR TITLE
Don't generate gitignore for Java projects

### DIFF
--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -133,9 +133,6 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
             TaskProvider<Copy> extractConjureIr) {
         ConjurePlugin.ignoreFromCheckUnusedDependencies(project);
 
-        TaskProvider<WriteGitignoreTask> generateGitIgnore = ConjurePlugin.createWriteGitignoreTask(
-                project, "gitignoreConjure", project.getProjectDir(), "/build/generated/\n");
-
         Provider<File> conjureIrFile = extractConjureIr.map(
                 irTask -> new File(irTask.getDestinationDir(), project.getName() + ".conjure.json"));
 
@@ -160,8 +157,10 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
                         return properties;
                     }));
                     task.getOutputDirectory()
-                            .set(project.getLayout().getProjectDirectory().dir("src/generated/java"));
-                    task.dependsOn(extractJavaTask, extractConjureIr, generateGitIgnore);
+                            .set(project.getLayout()
+                                    .getBuildDirectory()
+                                    .dir("generated/sources/conjure-java-local-java/java/main"));
+                    task.dependsOn(extractJavaTask, extractConjureIr);
                 });
 
         ConjurePlugin.addGeneratedToMainSourceSet(project, generateJava);

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -134,7 +134,7 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
         ConjurePlugin.ignoreFromCheckUnusedDependencies(project);
 
         TaskProvider<WriteGitignoreTask> generateGitIgnore = ConjurePlugin.createWriteGitignoreTask(
-                project, "gitignoreConjure", project.getProjectDir(), ConjurePlugin.JAVA_GITIGNORE_CONTENTS);
+                project, "gitignoreConjure", project.getProjectDir(), "/build/generated/\n");
 
         Provider<File> conjureIrFile = extractConjureIr.map(
                 irTask -> new File(irTask.getDestinationDir(), project.getName() + ".conjure.json"));
@@ -159,7 +159,8 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
                                 sanitizePackageName(project.getGroup().toString()));
                         return properties;
                     }));
-                    task.getOutputDirectory().set(project.file(ConjurePlugin.JAVA_GENERATED_SOURCE_DIRNAME));
+                    task.getOutputDirectory()
+                            .set(project.getLayout().getProjectDirectory().dir("src/generated/java"));
                     task.dependsOn(extractJavaTask, extractConjureIr, generateGitIgnore);
                 });
 

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
@@ -90,9 +90,6 @@ public final class ConjureLocalPlugin implements Plugin<Project> {
 
         subproj.getPluginManager().apply(JavaLibraryPlugin.class);
 
-        TaskProvider<WriteGitignoreTask> gitignoreConjureJava = ConjurePlugin.createWriteGitignoreTask(
-                subproj, "gitignoreConjureJava", subproj.getProjectDir(), ConjurePlugin.JAVA_GITIGNORE_CONTENTS);
-
         TaskProvider<ConjureLocalGenerateGenericTask> generateJava = project.getTasks()
                 .register("generateJava", ConjureLocalGenerateGenericTask.class, task -> {
                     task.setDescription("Generates Java bindings for remote Conjure definitions.");
@@ -114,7 +111,6 @@ public final class ConjureLocalPlugin implements Plugin<Project> {
                                     .getBuildDirectory()
                                     .dir("generated/sources/conjure-local-java/java/main"));
 
-                    task.dependsOn(gitignoreConjureJava);
                     task.dependsOn(extractJavaTask);
 
                     subproj.getDependencies().add("api", subproj);

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -84,8 +84,6 @@ public final class ConjurePlugin implements Plugin<Project> {
     static final String JAVA_UNDERTOW_SUFFIX = "undertow";
     static final ImmutableSet<String> JAVA_PROJECT_SUFFIXES = ImmutableSet.of(
             JAVA_DIALOGUE_SUFFIX, JAVA_OBJECTS_SUFFIX, JAVA_JERSEY_SUFFIX, JAVA_RETROFIT_SUFFIX, JAVA_UNDERTOW_SUFFIX);
-    static final String JAVA_GENERATED_SOURCE_DIRNAME = "src/generated/java";
-    static final String JAVA_GITIGNORE_CONTENTS = "/build/generated/\n";
 
     private static final ImmutableSet<String> FIRST_CLASS_GENERATOR_PROJECT_NAMES = ImmutableSet.<String>builder()
             .addAll(JAVA_PROJECT_SUFFIXES)
@@ -215,8 +213,6 @@ public final class ConjurePlugin implements Plugin<Project> {
         return parentProject.project(derivedProjectPath(parentProject, projectName), subproj -> {
             subproj.getPluginManager().apply(JavaLibraryPlugin.class);
             ignoreFromCheckUnusedDependencies(subproj);
-            TaskProvider<WriteGitignoreTask> writeGitignoreTask = createWriteGitignoreTask(
-                    subproj, "gitignoreConjure" + upperSuffix, subproj.getProjectDir(), JAVA_GITIGNORE_CONTENTS);
             TaskProvider<ConjureGeneratorTask> conjureGeneratorTask = parentProject
                     .getTasks()
                     .register("compileConjure" + upperSuffix, ConjureGeneratorTask.class, task -> {
@@ -230,7 +226,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                                         .getBuildDirectory()
                                         .dir("generated/sources/conjure-" + projectSuffix + "/java/main"));
                         task.setSource(compileIrTask);
-                        task.dependsOn(extractJavaTask, compileIrTask, writeGitignoreTask);
+                        task.dependsOn(extractJavaTask, compileIrTask);
                     });
             addGeneratedToMainSourceSet(subproj, conjureGeneratorTask);
             subproj.getTasks().named("compileJava").configure(t -> t.dependsOn(conjureGeneratorTask));

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPluginIntegrationSpec.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPluginIntegrationSpec.groovy
@@ -87,7 +87,7 @@ class ConjureJavaLocalCodegenPluginIntegrationSpec extends IntegrationSpec {
         result.wasExecuted("extractConjureIr")
         result.wasExecuted("conjure-api:generateConjure")
         fileExists("build/conjure-ir/conjure-api.conjure.json")
-        fileExists('conjure-api/src/generated/java/test/groupwithdashes/com/palantir/conjure/spec/ConjureDefinition.java')
+        fileExists('conjure-api/build/generated/sources/conjure-java-local-java/java/main/test/groupwithdashes/com/palantir/conjure/spec/ConjureDefinition.java')
         result.standardOutput.contains "with args: [--jersey, --jetbrainsContractAnnotations, --packagePrefix=test.groupwithdashes]"
         result.standardOutput.contains "with args: [--jetbrainsContractAnnotations, --objects, --packagePrefix=test.groupwithdashes]"
     }
@@ -108,7 +108,7 @@ class ConjureJavaLocalCodegenPluginIntegrationSpec extends IntegrationSpec {
 
         then:
         result.wasExecuted("extractConjureIr")
-        fileExists('conjure-api/src/generated/java/user/group/com/palantir/conjure/spec/ConjureDefinition.java')
+        fileExists('conjure-api/build/generated/sources/conjure-java-local-java/java/main/user/group/com/palantir/conjure/spec/ConjureDefinition.java')
         result.standardOutput.contains "with args: [--jetbrainsContractAnnotations, --objects, --packagePrefix=user.group]"
     }
 
@@ -123,7 +123,7 @@ class ConjureJavaLocalCodegenPluginIntegrationSpec extends IntegrationSpec {
         result.wasExecuted(':conjure-api:compileJava')
         result.wasExecuted(':conjure-api:generateConjure')
 
-        fileExists('conjure-api/src/generated/java/test/group/com/palantir/conjure/spec/ConjureDefinition.java')
+        fileExists('conjure-api/build/generated/sources/conjure-java-local-java/java/main/test/group/com/palantir/conjure/spec/ConjureDefinition.java')
     }
 
     def 'sets up idea source sets correctly'() {
@@ -144,7 +144,7 @@ class ConjureJavaLocalCodegenPluginIntegrationSpec extends IntegrationSpec {
         def sourcesFolderUrls = module.component.content.sourceFolder.@url
 
         sourcesFolderUrls.size() == 1
-        sourcesFolderUrls.contains('file://$MODULE_DIR$/src/generated/java')
+        sourcesFolderUrls.contains('file://$MODULE_DIR$/build/generated/sources/conjure-java-local-java/java/main')
     }
 
     def 'embeds product dependencies correctly'() {

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -127,8 +127,6 @@ class ConjurePluginTest extends IntegrationSpec {
         // java
         fileExists(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/java/main/test/test/api/StringExample.java'))
         file(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/java/main/test/test/api/StringExample.java')).text.contains('ignoreUnknown')
-        fileExists(prefixPath(prefix, 'api-objects/.gitignore'))
-        file(prefixPath(prefix, 'api-objects/.gitignore')).readLines() == ['/build/generated/']
 
         // typescript
         fileExists(prefixPath(prefix, 'api-typescript/src/api/index.ts'))
@@ -168,7 +166,6 @@ class ConjurePluginTest extends IntegrationSpec {
         result.wasExecuted(':api:compileConjureDialogue')
 
         fileExists(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/java/main/test/test/api/StringExample.java'))
-        fileExists(prefixPath(prefix, 'api-objects/.gitignore'))
 
         where:
         location   | prefix
@@ -229,7 +226,6 @@ class ConjurePluginTest extends IntegrationSpec {
         result.wasExecuted(':api:compileConjureJersey')
 
         fileExists(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/java/main/test/test/api/StringExample.java'))
-        fileExists(prefixPath(prefix, 'api-objects/.gitignore'))
 
         where:
         location   | prefix
@@ -301,12 +297,6 @@ class ConjurePluginTest extends IntegrationSpec {
         ExecutionResult result = runTasksSuccessfully("compileConjure")
 
         then:
-        result.wasUpToDate(prefixProject(prefix, 'api-objects:gitignoreConjureObjects'))
-        result.wasUpToDate(prefixProject(prefix, 'api-jersey:gitignoreConjureJersey'))
-        result.wasUpToDate(prefixProject(prefix, 'api-retrofit:gitignoreConjureRetrofit'))
-        result.wasUpToDate(prefixProject(prefix, 'api-typescript:gitignoreConjureTypeScript'))
-        result.wasUpToDate(prefixProject(prefix, 'api-undertow:gitignoreConjureUndertow'))
-        result.wasUpToDate(prefixProject(prefix, 'api-dialogue:gitignoreConjureDialogue'))
         result.wasUpToDate(':api:compileConjureObjects')
         result.wasUpToDate(':api:compileConjureJersey')
         result.wasUpToDate(':api:compileConjureRetrofit')


### PR DESCRIPTION
These `.gitignore` files are no longer necessary after https://github.com/palantir/gradle-conjure/pull/1401.