### PR TITLE
Correctly parse product name out of filename when producing local conjure

### DIFF
--- a/changelog/@unreleased/pr-1416.v2.yml
+++ b/changelog/@unreleased/pr-1416.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Conjure-local generates code into correct directory also when called
+    on RC- and other more complex versions
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/1416

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalGenerateGenericTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalGenerateGenericTask.java
@@ -18,8 +18,6 @@ package com.palantir.gradle.conjure;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
-import com.palantir.sls.versions.OrderableSlsVersion;
-import groovy.lang.Tuple2;
 import java.io.File;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -33,9 +31,9 @@ public abstract class ConjureLocalGenerateGenericTask extends ConjureLocalGenera
 
     @VisibleForTesting
     static Map<String, Supplier<Object>> resolveProductMetadata(String productName) {
-        Tuple2<String, OrderableSlsVersion> nameAndVersion = parseProductNameAndVersion(productName);
-        String irName = nameAndVersion.getV1();
-        String irVersion = nameAndVersion.getV2().getValue();
+        ProductNameAndVersion nameAndVersion = parseProductNameAndVersion(productName);
+        String irName = nameAndVersion.name();
+        String irVersion = nameAndVersion.version().getValue();
 
         return ImmutableMap.of("productName", () -> irName, "productVersion", () -> irVersion);
     }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalGenerateGenericTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalGenerateGenericTask.java
@@ -19,15 +19,12 @@ package com.palantir.gradle.conjure;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.sls.versions.OrderableSlsVersion;
+import groovy.lang.Tuple2;
 import java.io.File;
 import java.util.Map;
 import java.util.function.Supplier;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public abstract class ConjureLocalGenerateGenericTask extends ConjureLocalGenerateTask {
-
-    private static final Pattern PATTERN = Pattern.compile("^([^.]+)-(.+?)(\\.conjure)?\\.json$");
 
     @Override
     protected final Map<String, Supplier<Object>> requiredOptions(File irFile) {
@@ -36,18 +33,9 @@ public abstract class ConjureLocalGenerateGenericTask extends ConjureLocalGenera
 
     @VisibleForTesting
     static Map<String, Supplier<Object>> resolveProductMetadata(String productName) {
-        Matcher matcher = PATTERN.matcher(productName);
-        if (!matcher.matches() || matcher.groupCount() < 2) {
-            throw new RuntimeException(String.format("Unable to parse conjure dependency name %s", productName));
-        }
-        String irName = matcher.group(1);
-        String irVersion = matcher.group(2);
-
-        if (!OrderableSlsVersion.check(irVersion)) {
-            throw new RuntimeException(String.format(
-                    "Unable to parse orderable SLS version from conjure dependency name %s, version %s",
-                    productName, irVersion));
-        }
+        Tuple2<String, OrderableSlsVersion> nameAndVersion = parseProductNameAndVersion(productName);
+        String irName = nameAndVersion.getV1();
+        String irVersion = nameAndVersion.getV2().getValue();
 
         return ImmutableMap.of("productName", () -> irName, "productVersion", () -> irVersion);
     }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalGenerateTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalGenerateTask.java
@@ -16,17 +16,41 @@
 
 package com.palantir.gradle.conjure;
 
+import com.palantir.sls.versions.OrderableSlsVersion;
+import groovy.lang.Tuple;
+import groovy.lang.Tuple2;
 import java.io.File;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.gradle.api.tasks.CacheableTask;
 
 @CacheableTask
 public abstract class ConjureLocalGenerateTask extends ConjureGeneratorTask {
 
+    protected static final Pattern PATTERN = Pattern.compile("^([^.]+)-(.+?)(\\.conjure)?\\.json$");
+
+    static Tuple2<String, OrderableSlsVersion> parseProductNameAndVersion(String filename) {
+        Matcher matcher = PATTERN.matcher(filename);
+        if (!matcher.matches() || matcher.groupCount() < 2) {
+            throw new RuntimeException(String.format("Unable to parse conjure dependency name %s", filename));
+        }
+        String irName = matcher.group(1);
+        Optional<OrderableSlsVersion> maybeIrVersion = OrderableSlsVersion.safeValueOf(matcher.group(2));
+
+        if (maybeIrVersion.isEmpty()) {
+            throw new RuntimeException(String.format(
+                    "Unable to parse orderable SLS version from conjure dependency name %s, version %s",
+                    filename, maybeIrVersion));
+        }
+        return Tuple.tuple(irName, maybeIrVersion.get());
+    }
+
     @Override
     protected final File outputDirectoryFor(File file) {
         // Strip extension and version
         return getOutputDirectory()
-                .dir(file.getName().substring(0, file.getName().lastIndexOf("-")))
+                .dir(parseProductNameAndVersion(file.getName()).getV1())
                 .get()
                 .getAsFile();
     }

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalGenerateTaskTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalGenerateTaskTest.groovy
@@ -25,8 +25,8 @@ class ConjureLocalGenerateTaskTest extends Specification {
         def productMetadata = ConjureLocalGenerateTask.parseProductNameAndVersion(fileName)
 
         then:
-        productMetadata.getV1() == expectedProductName
-        productMetadata.getV2().getValue() == expectedProductVersion
+        productMetadata.name() == expectedProductName
+        productMetadata.version().getValue() == expectedProductVersion
 
         where:
         fileName                           | expectedProductName | expectedProductVersion

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalGenerateTaskTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalGenerateTaskTest.groovy
@@ -1,0 +1,54 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.conjure;
+
+import spock.lang.Specification;
+
+class ConjureLocalGenerateTaskTest extends Specification {
+
+    def "correctly parses product metadata"() {
+        when:
+        def productMetadata = ConjureLocalGenerateTask.parseProductNameAndVersion(fileName)
+
+        then:
+        productMetadata.getV1() == expectedProductName
+        productMetadata.getV2().getValue() == expectedProductVersion
+
+        where:
+        fileName                           | expectedProductName | expectedProductVersion
+        'foo-1.0.0.json'                   | "foo"               | '1.0.0'
+        "foo-baz-2-1.0.0.json"             | "foo-baz-2"         | "1.0.0"
+        "foo-1.0.0.conjure.json"           | "foo"               | "1.0.0"
+        "foo-1.0.0-rc1.conjure.json"       | "foo"               | "1.0.0-rc1"
+        "foo-1.0.0-12-gabcd.conjure.json"  | "foo"               | "1.0.0-12-gabcd"
+    }
+
+    def "fails to parse invalid names"() {
+        when:
+        ConjureLocalGenerateTask.parseProductNameAndVersion(fileName)
+
+        then:
+        RuntimeException ex = thrown()
+        ex.message.contains(fileName)
+
+        where:
+        fileName                      | _
+        "invalid-name.json"           | _
+        "invalid-version-1.x.0.json"  | _
+        "invalid-structure-1.2.0.tgz" | _
+    }
+}


### PR DESCRIPTION
## Before this PR
At least producing rust code would fail when version is something else than a "1.2.3", ie RCs and commits, producing the generated code into a folder like "product-1.2.3" (for "product-1.2.3-rc1") instead of "product". 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Conjure-local generates code into correct directory also when called on RC- and other more complex versions
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

