### PR TITLE
Include versions in all dependencies

### DIFF
--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/Dependencies.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/Dependencies.java
@@ -26,9 +26,9 @@ final class Dependencies {
     static final String JAXRS_API_JAKARTA = "jakarta.ws.rs:jakarta.ws.rs-api:3.0.0";
     static final String JAXRS_API_JAVAX = "javax.ws.rs:javax.ws.rs-api:2.1.1";
 
-    static final String CONJURE_JAVA_LIB = "com.palantir.conjure.java:conjure-lib";
-    static final String CONJURE_UNDERTOW_LIB = "com.palantir.conjure.java:conjure-undertow-lib";
-    static final String DIALOGUE_TARGET = "com.palantir.dialogue:dialogue-target";
+    static final String CONJURE_JAVA_LIB = "com.palantir.conjure.java:conjure-lib:8.22.0";
+    static final String CONJURE_UNDERTOW_LIB = "com.palantir.conjure.java:conjure-undertow-lib:8.22.0";
+    static final String DIALOGUE_TARGET = "com.palantir.dialogue:dialogue-target:3.135.0";
     /**
      * Includes a version in order to ensure upgrades that opt into annotations
      * have a minimum version rather than failing builds.

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPluginIntegrationSpec.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPluginIntegrationSpec.groovy
@@ -46,7 +46,6 @@ class ConjureJavaLocalCodegenPluginIntegrationSpec extends IntegrationSpec {
                 resolutionStrategy {
                     force 'com.palantir.conjure:conjure:${TestVersions.CONJURE}'
                     force 'com.palantir.conjure.java:conjure-java:${TestVersions.CONJURE_JAVA}'
-                    force 'com.palantir.conjure.java:conjure-lib:${TestVersions.CONJURE_JAVA}'
                 }
            }
         }

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -60,10 +60,7 @@ class ConjurePluginTest extends IntegrationSpec {
                 resolutionStrategy {
                     force 'com.palantir.conjure:conjure:${TestVersions.CONJURE}'
                     force 'com.palantir.conjure.java:conjure-java:${TestVersions.CONJURE_JAVA}'
-                    force 'com.palantir.conjure.java:conjure-lib:${TestVersions.CONJURE_JAVA}'
-                    force 'com.palantir.conjure.java:conjure-undertow-lib:${TestVersions.CONJURE_JAVA}'
                     force 'com.palantir.conjure.typescript:conjure-typescript:${TestVersions.CONJURE_TYPESCRIPT}'
-                    force 'com.palantir.dialogue:dialogue-target:${TestVersions.DIALOGUE}'
                 }
             }
         }

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
@@ -51,8 +51,6 @@ class ConjureServiceDependencyTest extends IntegrationSpec {
                 resolutionStrategy {
                     force 'com.palantir.conjure:conjure:${TestVersions.CONJURE}'
                     force 'com.palantir.conjure.java:conjure-java:${TestVersions.CONJURE_JAVA}'
-                    force 'com.palantir.conjure.java:conjure-lib:${TestVersions.CONJURE_JAVA}'
-                    force 'com.palantir.conjure.java:conjure-undertow-lib:${TestVersions.CONJURE_JAVA}' 
                     force 'com.palantir.conjure.typescript:conjure-typescript:${TestVersions.CONJURE_TYPESCRIPT}'
                 }
             }   

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/TestVersions.java
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/TestVersions.java
@@ -24,6 +24,4 @@ public final class TestVersions {
     public static final String CONJURE_POSTMAN = "0.1.2";
     public static final String CONJURE_PYTHON = "3.11.6";
     public static final String CONJURE_TYPESCRIPT = "3.8.1";
-
-    public static final String DIALOGUE = "3.135.0";
 }


### PR DESCRIPTION
This ensures that consumer get functioning dependencies when we start relying on new feature of these libraries.

I've just used the latest versions of `conjure-java` and `dialogue`, rather than trying to figure out the minimum required version of these dependencies.

We removed support for Retrofit clients in https://github.com/palantir/conjure-java/pull/2135, so that is no longer tested.