### PR TITLE
Remove support for Retrofit client generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ conjure {
     }
 
     java {
-        retrofitCompletableFutures = true
+        useImmutableBytes = true
     }
 }
 ```
@@ -74,7 +74,7 @@ serviceDependencies {
 
 For conjure-typescript, this information is passed as an extra flag, `--productDependencies=your-project/build/service-dependencies.json`, which is used to embed information in the resultant package.json.
 
-For conjure-java, this information is directly embedded into the Jar for the `-jersey` and `-retrofit` projects.  It is stored as a manifest property, `Sls-Recommended-Product-Dependencies`, which can be detected by [sls-packaging](https://github.com/palantir/sls-packaging).
+For conjure-java, this information is directly embedded into the Jar for the `-jersey` and `-dialogue` projects.  It is stored as a manifest property, `Sls-Recommended-Product-Dependencies`, which can be detected by [sls-packaging](https://github.com/palantir/sls-packaging).
 
 ### Typescript
 

--- a/changelog/@unreleased/pr-1441.v2.yml
+++ b/changelog/@unreleased/pr-1441.v2.yml
@@ -1,0 +1,5 @@
+type: deprecation
+deprecation:
+  description: Retrofit client generation is no longer supported.
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/1441

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
@@ -45,8 +45,7 @@ public final class ConjureLocalPlugin implements Plugin<Project> {
     private static final String TYPESCRIPT_PROJECT_NAME = "typescript";
     private static final ImmutableSet<String> FIRST_CLASS_GENERATOR_PROJECT_NAMES =
             ImmutableSet.of(JAVA_PROJECT_NAME, PYTHON_PROJECT_NAME, TYPESCRIPT_PROJECT_NAME);
-    private static final ImmutableSet<String> UNSAFE_JAVA_OPTIONS =
-            ImmutableSet.of("objects", "retrofit", "jersey", "undertow");
+    private static final ImmutableSet<String> UNSAFE_JAVA_OPTIONS = ImmutableSet.of("objects", "jersey", "undertow");
 
     @Override
     public void apply(Project project) {

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -80,10 +80,9 @@ public final class ConjurePlugin implements Plugin<Project> {
     static final String JAVA_DIALOGUE_SUFFIX = "dialogue";
     static final String JAVA_OBJECTS_SUFFIX = "objects";
     static final String JAVA_JERSEY_SUFFIX = "jersey";
-    static final String JAVA_RETROFIT_SUFFIX = "retrofit";
     static final String JAVA_UNDERTOW_SUFFIX = "undertow";
-    static final ImmutableSet<String> JAVA_PROJECT_SUFFIXES = ImmutableSet.of(
-            JAVA_DIALOGUE_SUFFIX, JAVA_OBJECTS_SUFFIX, JAVA_JERSEY_SUFFIX, JAVA_RETROFIT_SUFFIX, JAVA_UNDERTOW_SUFFIX);
+    static final ImmutableSet<String> JAVA_PROJECT_SUFFIXES =
+            ImmutableSet.of(JAVA_DIALOGUE_SUFFIX, JAVA_OBJECTS_SUFFIX, JAVA_JERSEY_SUFFIX, JAVA_UNDERTOW_SUFFIX);
 
     private static final ImmutableSet<String> FIRST_CLASS_GENERATOR_PROJECT_NAMES = ImmutableSet.<String>builder()
             .addAll(JAVA_PROJECT_SUFFIXES)
@@ -163,7 +162,6 @@ public final class ConjurePlugin implements Plugin<Project> {
                 ImmutableMap.<String, BiConsumer<Project, Supplier<GeneratorOptions>>>builder()
                         .put(JAVA_OBJECTS_SUFFIX, ConjurePlugin::setupObjectsProject)
                         .put(JAVA_DIALOGUE_SUFFIX, ConjurePlugin::setupDialogueProject)
-                        .put(JAVA_RETROFIT_SUFFIX, ConjurePlugin::setupRetrofitProject)
                         .put(JAVA_JERSEY_SUFFIX, ConjurePlugin::setupJerseyProject)
                         .put(JAVA_UNDERTOW_SUFFIX, ConjurePlugin::setupUndertowProject)
                         .buildOrThrow();
@@ -286,16 +284,6 @@ public final class ConjurePlugin implements Plugin<Project> {
         project.getDependencies().add("api", Dependencies.DIALOGUE_TARGET);
     }
 
-    private static void setupRetrofitProject(Project project, Supplier<GeneratorOptions> optionsSupplier) {
-        boolean useJakarta = Dependencies.isJakartaPackages(optionsSupplier.get());
-        project.getDependencies().add("api", "com.google.guava:guava");
-        project.getDependencies().add("api", "com.squareup.retrofit2:retrofit");
-        project.getDependencies()
-                .add(
-                        "compileOnly",
-                        useJakarta ? Dependencies.ANNOTATION_API_JAKARTA : Dependencies.ANNOTATION_API_JAVAX);
-    }
-
     private static void setupJerseyProject(Project project, Supplier<GeneratorOptions> optionsSupplier) {
         boolean useJakarta = Dependencies.isJakartaPackages(optionsSupplier.get());
         project.getDependencies()
@@ -328,9 +316,6 @@ public final class ConjurePlugin implements Plugin<Project> {
                     Method ignoreMethod = task.getClass().getMethod("ignore", String.class, String.class);
                     List<String> conjureJavaLibComponents = Splitter.on(':').splitToList(Dependencies.CONJURE_JAVA_LIB);
                     ignoreMethod.invoke(task, conjureJavaLibComponents.get(0), conjureJavaLibComponents.get(1));
-                    // also ignore guava since retrofit adds it...
-                    ignoreMethod.invoke(task, "com.google.guava", "guava");
-                    // And jetbrains annotations
                     ignoreMethod.invoke(task, "org.jetbrains", "annotations");
                 } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
                     log.warn("Failed to ignore conjure-lib from baseline's checkUnusedDependencies", e);

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureGeneratorTaskTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureGeneratorTaskTest.groovy
@@ -47,14 +47,6 @@ class ConjureGeneratorTaskTest extends IntegrationSpec {
 
         createFile('api/build.gradle') << """
         apply plugin: 'com.palantir.conjure'
-
-        subprojects {
-            pluginManager.withPlugin 'java', {
-                dependencies {
-                    implementation 'com.palantir.conjure.java:conjure-lib:${TestVersions.CONJURE_JAVA}'
-                }
-            }
-        }
         """.stripIndent()
 
         createFile('api/src/main/conjure/api.yml') << '''

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPluginIntegrationSpec.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPluginIntegrationSpec.groovy
@@ -43,16 +43,11 @@ class ConjureJavaLocalCodegenPluginIntegrationSpec extends IntegrationSpec {
             }
 
             configurations.all {
-               resolutionStrategy {
-                   force 'com.palantir.conjure.java:conjure-java:${TestVersions.CONJURE_JAVA}'
-                   force 'com.palantir.conjure.java:conjure-lib:${TestVersions.CONJURE_JAVA}'
-                   force 'com.palantir.conjure:conjure:${TestVersions.CONJURE}'
-
-                   force 'com.fasterxml.jackson.core:jackson-databind:2.10.2'
-                   force 'com.fasterxml.jackson.core:jackson-annotations:2.10.2'
-                   force 'com.palantir.safe-logging:safe-logging:1.12.0'
-                   force 'com.palantir.safe-logging:preconditions:1.12.0'
-               }
+                resolutionStrategy {
+                    force 'com.palantir.conjure:conjure:${TestVersions.CONJURE}'
+                    force 'com.palantir.conjure.java:conjure-java:${TestVersions.CONJURE_JAVA}'
+                    force 'com.palantir.conjure.java:conjure-lib:${TestVersions.CONJURE_JAVA}'
+                }
            }
         }
         

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalPluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalPluginTest.groovy
@@ -37,11 +37,11 @@ class ConjureLocalPluginTest extends IntegrationSpec {
             configurations.all {
                resolutionStrategy {
                    failOnVersionConflict()
-                   force 'com.palantir.conjure.java:conjure-java:${TestVersions.CONJURE_JAVA}'
-                   force 'com.palantir.conjure.typescript:conjure-typescript:${TestVersions.CONJURE_TYPESCRIPT}'
-                   force 'com.palantir.conjure.python:conjure-python:${TestVersions.CONJURE_PYTHON}'
                    force 'com.palantir.conjure:conjure:${TestVersions.CONJURE}'
+                   force 'com.palantir.conjure.java:conjure-java:${TestVersions.CONJURE_JAVA}'
                    force 'com.palantir.conjure.postman:conjure-postman:${TestVersions.CONJURE_POSTMAN}'
+                   force 'com.palantir.conjure.python:conjure-python:${TestVersions.CONJURE_PYTHON}'
+                   force 'com.palantir.conjure.typescript:conjure-typescript:${TestVersions.CONJURE_TYPESCRIPT}'
                }
            }
         }

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -31,7 +31,6 @@ class ConjurePluginTest extends IntegrationSpec {
         include 'api'
         include 'api:api-objects'
         include 'api:api-jersey'
-        include 'api:api-retrofit'
         include 'api:api-typescript'
         include 'api:api-undertow'
         include 'api:api-dialogue'
@@ -59,19 +58,12 @@ class ConjurePluginTest extends IntegrationSpec {
 
             configurations.all {
                 resolutionStrategy {
+                    force 'com.palantir.conjure:conjure:${TestVersions.CONJURE}'
                     force 'com.palantir.conjure.java:conjure-java:${TestVersions.CONJURE_JAVA}'
                     force 'com.palantir.conjure.java:conjure-lib:${TestVersions.CONJURE_JAVA}'
-                    force 'com.palantir.dialogue:dialogue-target:${TestVersions.CONJURE_JAVA_DIALOG}'
                     force 'com.palantir.conjure.java:conjure-undertow-lib:${TestVersions.CONJURE_JAVA}'
-                    force 'com.palantir.conjure:conjure:${TestVersions.CONJURE}'
                     force 'com.palantir.conjure.typescript:conjure-typescript:${TestVersions.CONJURE_TYPESCRIPT}'
-
-                    force 'com.fasterxml.jackson.core:jackson-annotations:2.10.2'
-                    force 'com.fasterxml.jackson.core:jackson-databind:2.10.2'
-                    force 'com.google.guava:guava:23.6.1-jre'
-                    force 'com.palantir.safe-logging:preconditions:1.12.0'
-                    force 'com.palantir.safe-logging:safe-logging:1.12.0'
-                    force 'com.squareup.retrofit2:retrofit:2.1.0'
+                    force 'com.palantir.dialogue:dialogue-target:${TestVersions.DIALOGUE}'
                 }
             }
         }
@@ -118,7 +110,6 @@ class ConjurePluginTest extends IntegrationSpec {
         result.wasExecuted(':api:compileConjure')
         result.wasExecuted(':api:compileConjureObjects')
         result.wasExecuted(':api:compileConjureJersey')
-        result.wasExecuted(':api:compileConjureRetrofit')
         result.wasExecuted(':api:compileConjureTypeScript')
         result.wasExecuted(':api:compileConjureUndertow')
         result.wasExecuted(':api:compileConjureDialogue')
@@ -158,8 +149,6 @@ class ConjurePluginTest extends IntegrationSpec {
         result.wasExecuted(':api:compileConjureObjects')
         result.wasExecuted(prefixProject(prefix, 'api-jersey:compileJava'))
         result.wasExecuted(':api:compileConjureJersey')
-        result.wasExecuted(prefixProject(prefix, 'api-retrofit:compileJava'))
-        result.wasExecuted(':api:compileConjureRetrofit')
         result.wasExecuted(prefixProject(prefix, 'api-undertow:compileJava'))
         result.wasExecuted(':api:compileConjureUndertow')
         result.wasExecuted(prefixProject(prefix, 'api-dialogue:compileJava'))
@@ -187,8 +176,6 @@ class ConjurePluginTest extends IntegrationSpec {
         result.wasExecuted(':api:compileConjureObjects')
         result.wasExecuted(prefixProject(prefix, 'api-jersey:compileJava'))
         result.wasExecuted(':api:compileConjureJersey')
-        result.wasExecuted(prefixProject(prefix, 'api-retrofit:compileJava'))
-        result.wasExecuted(':api:compileConjureRetrofit')
         result.wasExecuted(prefixProject(prefix, 'api-undertow:compileJava'))
         result.wasExecuted(':api:compileConjureUndertow')
         result.wasExecuted(prefixProject(prefix, 'api-dialogue:compileJava'))
@@ -199,8 +186,6 @@ class ConjurePluginTest extends IntegrationSpec {
         result2.wasUpToDate(':api:compileConjureObjects')
         result2.wasUpToDate(prefixProject(prefix, 'api-jersey:compileJava'))
         result2.wasUpToDate(':api:compileConjureJersey')
-        result2.wasUpToDate(prefixProject(prefix, 'api-retrofit:compileJava'))
-        result2.wasUpToDate(':api:compileConjureRetrofit')
         result2.wasUpToDate(prefixProject(prefix, 'api-undertow:compileJava'))
         result2.wasUpToDate(':api:compileConjureUndertow')
         result2.wasUpToDate(prefixProject(prefix, 'api-dialogue:compileJava'))
@@ -243,7 +228,6 @@ class ConjurePluginTest extends IntegrationSpec {
         then:
         fileExists(prefixPath(prefix, 'api-jersey/build/generated/sources/conjure-jersey/java/main'))
         fileExists(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/java/main'))
-        fileExists(prefixPath(prefix, 'api-retrofit/build/generated/sources/conjure-retrofit/java/main'))
         fileExists(prefixPath(prefix, 'api-undertow/build/generated/sources/conjure-undertow/java/main'))
         fileExists(prefixPath(prefix, 'api-dialogue/build/generated/sources/conjure-dialogue/java/main'))
 
@@ -253,13 +237,11 @@ class ConjurePluginTest extends IntegrationSpec {
         then:
         result.wasExecuted(':api:cleanCompileConjureJersey')
         result.wasExecuted(':api:cleanCompileConjureObjects')
-        result.wasExecuted(':api:cleanCompileConjureRetrofit')
         result.wasExecuted(':api:cleanCompileConjureUndertow')
         result.wasExecuted(':api:cleanCompileConjureDialogue')
 
         !fileExists(prefixPath(prefix, 'api-jersey/build/generated/sources/conjure-jersey/java/main'))
         !fileExists(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/java/main'))
-        !fileExists(prefixPath(prefix, 'api-retrofit/build/generated/sources/conjure-retrofit/java/main'))
         !fileExists(prefixPath(prefix, 'api-undertow/build/generated/sources/conjure-undertow/java/main'))
         !fileExists(prefixPath(prefix, 'api-dialogue/build/generated/sources/conjure-dialogue/java/main'))
 
@@ -299,7 +281,6 @@ class ConjurePluginTest extends IntegrationSpec {
         then:
         result.wasUpToDate(':api:compileConjureObjects')
         result.wasUpToDate(':api:compileConjureJersey')
-        result.wasUpToDate(':api:compileConjureRetrofit')
         result.wasUpToDate(':api:compileConjureTypeScript')
         result.wasUpToDate(':api:compileConjureUndertow')
         result.wasUpToDate(':api:compileConjureDialogue')
@@ -343,7 +324,6 @@ class ConjurePluginTest extends IntegrationSpec {
         then:
         result.wasExecuted(':api:compileConjureObjects')
         result.wasExecuted(':api:compileConjureJersey')
-        result.wasExecuted(':api:compileConjureRetrofit')
         result.wasExecuted(':api:compileConjureTypeScript')
         result.wasExecuted(':api:compileConjureUndertow')
         result.wasExecuted(':api:compileConjureDialogue')
@@ -417,7 +397,6 @@ class ConjurePluginTest extends IntegrationSpec {
         result.wasExecuted(':api:compileConjure')
         result.wasExecuted(':api:compileConjureJersey')
         result.wasExecuted(':api:compileConjureObjects')
-        result.wasExecuted(':api:compileConjureRetrofit')
         result.wasExecuted(":api:compileIr")
 
         fileExists('api/build/conjure/internal-import.yml')
@@ -425,8 +404,6 @@ class ConjurePluginTest extends IntegrationSpec {
 
         // java
         file(prefixPath(prefix, 'api-jersey/build/generated/sources/conjure-jersey/java/main/test/api/service/TestServiceFoo2.java')).text.contains(
-                'import test.api.internal.InternalImport;')
-        file(prefixPath(prefix, 'api-retrofit/build/generated/sources/conjure-retrofit/java/main/test/api/service/TestServiceFoo2Retrofit.java')).text.contains(
                 'import test.api.internal.InternalImport;')
         fileExists(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/java/main/test/api/internal/InternalImport.java'))
 

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
@@ -49,10 +49,10 @@ class ConjureServiceDependencyTest extends IntegrationSpec {
             }
             configurations.all {
                 resolutionStrategy {
+                    force 'com.palantir.conjure:conjure:${TestVersions.CONJURE}'
                     force 'com.palantir.conjure.java:conjure-java:${TestVersions.CONJURE_JAVA}'
                     force 'com.palantir.conjure.java:conjure-lib:${TestVersions.CONJURE_JAVA}'
-                    force 'com.palantir.conjure.java:conjure-undertow-lib:${TestVersions.CONJURE_JAVA}'
-                    force 'com.palantir.conjure:conjure:${TestVersions.CONJURE}'
+                    force 'com.palantir.conjure.java:conjure-undertow-lib:${TestVersions.CONJURE_JAVA}' 
                     force 'com.palantir.conjure.typescript:conjure-typescript:${TestVersions.CONJURE_TYPESCRIPT}'
                 }
             }   

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/TestVersions.java
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/TestVersions.java
@@ -19,10 +19,11 @@ package com.palantir.gradle.conjure;
 public final class TestVersions {
     private TestVersions() {}
 
-    public static final String CONJURE = "4.30.0";
-    public static final String CONJURE_JAVA = "5.17.0";
-    public static final String CONJURE_JAVA_DIALOG = "1.50.0";
+    public static final String CONJURE = "4.48.0";
+    public static final String CONJURE_JAVA = "8.22.0";
+    public static final String CONJURE_POSTMAN = "0.1.2";
     public static final String CONJURE_PYTHON = "3.11.6";
     public static final String CONJURE_TYPESCRIPT = "3.8.1";
-    public static final String CONJURE_POSTMAN = "0.1.2";
+
+    public static final String DIALOGUE = "3.135.0";
 }


### PR DESCRIPTION
Same as https://github.com/palantir/gradle-conjure/pull/1440, minus the change to recommend specific versions of dependencies.

Primary motivation is to upgrade and clean up dependencies used in tests.

We removed support for Retrofit clients in https://github.com/palantir/conjure-java/pull/2135, so that is no longer tested or supported.