### PR TITLE
add dependency on error_prone_annotations to objects projects

### DIFF
--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -109,6 +109,7 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
     private static void configureDependencies(Project project, ConjureExtension extension) {
         project.getDependencies().add("api", Dependencies.CONJURE_JAVA_LIB);
         project.getDependencies().add("api", Dependencies.JETBRAINS_ANNOTATIONS);
+        project.getDependencies().add("api", Dependencies.ERRORPRONE_ANNOTATIONS);
         boolean useJakarta = Dependencies.isJakartaPackages(extension.getJava());
         project.getDependencies()
                 .add(

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -278,6 +278,7 @@ public final class ConjurePlugin implements Plugin<Project> {
     private static void setupObjectsProject(Project project, Supplier<GeneratorOptions> _optionsSupplier) {
         project.getDependencies().add("api", Dependencies.CONJURE_JAVA_LIB);
         project.getDependencies().add("api", Dependencies.JETBRAINS_ANNOTATIONS);
+        project.getDependencies().add("api", Dependencies.ERRORPRONE_ANNOTATIONS);
     }
 
     private static void setupDialogueProject(Project project, Supplier<GeneratorOptions> _optionsSupplier) {

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/Dependencies.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/Dependencies.java
@@ -34,6 +34,12 @@ final class Dependencies {
      * have a minimum version rather than failing builds.
      */
     static final String JETBRAINS_ANNOTATIONS = "org.jetbrains:annotations:23.0.0";
+    /**
+     * Starting with conjure-lib version 8.18.0, the build() method of generated builders
+     * add a @CheckReturnValue annotation from errorprone.
+     * See: https://github.com/palantir/conjure-java/pull/2282
+     */
+    static final String ERRORPRONE_ANNOTATIONS = "com.google.errorprone:error_prone_annotations";
 
     private static final String JAKARTA_PACKAGES = "jakartaPackages";
     private static final String JERSEY = "jersey";


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

