### PR TITLE
generateNpmrc task does not depend on running compileTypeScript first

### DIFF
--- a/changelog/@unreleased/pr-1461.v2.yml
+++ b/changelog/@unreleased/pr-1461.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Generate .npmrc before installing TypeScript dependencies
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/1461

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -383,6 +383,15 @@ public final class ConjurePlugin implements Plugin<Project> {
                             task.commandLine(npmCommand, "install", "--no-package-lock", "--no-production");
                             task.workingDir(srcDirectory);
                             task.dependsOn(compileConjureTypeScript);
+                            if (Boolean.parseBoolean(options.get()
+                                    .getProperties()
+                                    .getOrDefault("installGeneratesNpmrc", "true")
+                                    .toString())) {
+                                // In most cases we want the installTypeScriptDependencies task to depend on
+                                // the generateNpmrc task, except for some tests that pull dependencies from
+                                // the actual https://registry.npmjs.org repository.
+                                task.dependsOn(generateNpmrc);
+                            }
                             task.getInputs().file(new File(srcDirectory, "package.json"));
                             task.getOutputs().dir(new File(srcDirectory, "node_modules"));
                         });

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -358,6 +358,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                 registerClean(project, compileConjureTypeScript);
 
                 String npmCommand = OsUtils.NPM_COMMAND_NAME;
+
                 TaskProvider<GenerateNpmrcTask> generateNpmrc = project.getTasks()
                         .register("generateNpmrc", GenerateNpmrcTask.class, task -> {
                             task.setDescription("Generates .npmrc file suitable to resolve and publish NPM artifacts");
@@ -381,7 +382,6 @@ public final class ConjurePlugin implements Plugin<Project> {
                         .register("installTypeScriptDependencies", Exec.class, task -> {
                             task.commandLine(npmCommand, "install", "--no-package-lock", "--no-production");
                             task.workingDir(srcDirectory);
-                            task.dependsOn(generateNpmrc);
                             task.dependsOn(compileConjureTypeScript);
                             task.getInputs().file(new File(srcDirectory, "package.json"));
                             task.getOutputs().dir(new File(srcDirectory, "node_modules"));

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GenerateNpmrcTask.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/GenerateNpmrcTask.java
@@ -35,10 +35,12 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodySubscribers;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Optional;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.logging.LogLevel;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputFile;
@@ -91,9 +93,8 @@ public class GenerateNpmrcTask extends DefaultTask {
     }
 
     private String normalizedRegistryUri() {
-        return registryUri.get().endsWith("/")
-                ? registryUri.get().substring(0, registryUri.get().length() - 1)
-                : registryUri.get();
+        String uri = registryUri.get();
+        return uri.endsWith("/") ? uri.substring(0, uri.length() - 1) : uri;
     }
 
     @TaskAction
@@ -129,7 +130,9 @@ public class GenerateNpmrcTask extends DefaultTask {
         String npmRcContents = scopeRegistry + "registry=" + normalizedUri + "/" + tokenString;
 
         try {
-            Files.writeString(outputFile.getAsFile().get().toPath(), npmRcContents, StandardCharsets.UTF_8);
+            Path npmrcPath = outputFile.getAsFile().get().toPath().toAbsolutePath();
+            Files.writeString(npmrcPath, npmRcContents, StandardCharsets.UTF_8);
+            getLogger().log(LogLevel.INFO, "Wrote npm config to {}", npmrcPath);
         } catch (@DoNotLog IOException e) {
             throw new SafeRuntimeException("Error writing npmrc file");
         }

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePublishTypeScriptTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePublishTypeScriptTest.groovy
@@ -115,7 +115,7 @@ class ConjurePublishTypeScriptTest extends IntegrationSpec {
         MockWebServer server = new MockWebServer()
         server.start(8888)
         // generateNpmrc will make request for token
-        server.enqueue(new MockResponse().setBody("{\"token\": \"theansweris42\"}"))
+        server.enqueue(new MockResponse().setBody("{\"token\": \"42\"}"))
         // npm install makes two requests to the registry
         server.enqueue(new MockResponse().setBody("""
         {
@@ -136,10 +136,10 @@ class ConjurePublishTypeScriptTest extends IntegrationSpec {
 
         file('api/build.gradle').text = """
         apply plugin: 'com.palantir.conjure'
+
         generateNpmrc.registryUri = "http://localhost:8888"
         generateNpmrc.username = "user"
         generateNpmrc.password = "pass"
-        tasks.installTypeScriptDependencies.dependsOn tasks.generateNpmrc
         """.stripIndent()
 
         when:
@@ -151,7 +151,7 @@ class ConjurePublishTypeScriptTest extends IntegrationSpec {
         server.takeRequest(100, TimeUnit.MILLISECONDS).path == "/conjure-client"
         server.takeRequest(100, TimeUnit.MILLISECONDS).path == "/typescript"
         file('api/api-typescript/src/.npmrc').text.contains('registry=http://localhost:8888/')
-        file('api/api-typescript/src/.npmrc').text.contains('//localhost:8888/:_authToken=theansweris42')
+        file('api/api-typescript/src/.npmrc').text.contains('//localhost:8888/:_authToken=42')
         result.wasExecuted('api:generateNpmrc')
         result.wasExecuted('api:compileConjureTypeScript')
         result.wasExecuted('api:installTypeScriptDependencies')
@@ -192,6 +192,12 @@ class ConjurePublishTypeScriptTest extends IntegrationSpec {
         file('api/build.gradle').text = """
         apply plugin: 'com.palantir.conjure'
 
+        conjure {
+            typescript {
+                installGeneratesNpmrc = false // test relies on pulling from actual https://registry.npmjs.org
+            }
+        }
+
         generateNpmrc.registryUri = "http://localhost:8888"
         generateNpmrc.username = "user"
         generateNpmrc.password = "pass"
@@ -220,6 +226,12 @@ class ConjurePublishTypeScriptTest extends IntegrationSpec {
         server.enqueue(new MockResponse())
         file('api/build.gradle').text = """
         apply plugin: 'com.palantir.conjure'
+
+        conjure {
+            typescript {
+                installGeneratesNpmrc = false // test relies on pulling from actual https://registry.npmjs.org
+            }
+        }
 
         generateNpmrc.registryUri = "http://localhost:8888"
         generateNpmrc.token = "registry-token"
@@ -254,6 +266,7 @@ class ConjurePublishTypeScriptTest extends IntegrationSpec {
         conjure {
             typescript {
                 packageName = "@test/api"
+                installGeneratesNpmrc = false // test relies on pulling from actual https://registry.npmjs.org
             }
         }
 

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePublishTypeScriptTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePublishTypeScriptTest.groovy
@@ -126,9 +126,12 @@ class ConjurePublishTypeScriptTest extends IntegrationSpec {
         """.stripIndent()
 
         when:
-        ExecutionResult result = runTasksSuccessfully('installTypeScriptDependencies')
+        ExecutionResult result = runTasks('installTypeScriptDependencies')
+        System.err.println(result.standardError)
+        System.out.println(result.standardOutput)
 
         then:
+        result.rethrowFailure() == result
         file('api/api-typescript/src/.npmrc').text.contains('registry=http://localhost:8888/')
         file('api/api-typescript/src/.npmrc').text.contains('//localhost:8888/:_authToken=theansweris42')
         result.wasExecuted('api:generateNpmrc')


### PR DESCRIPTION
## Before this PR

Some projects need to use an alternate NPM registry for installing dependencies, however; the `.npmrc` was not generated until after attempting to `installTypeScriptDependencies`

https://github.com/palantir/gradle-conjure/pull/1349/ made this issue fail earlier, blocking `gradle-conjure` upgrades beyond [5.42.0](https://github.com/palantir/gradle-conjure/releases/tag/5.42.0).

```
Process 'command 'npm'' finished with non-zero exit value 1

* Causal chain is:
	org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':foo-api:installTypeScriptDependencies'.
	org.gradle.process.internal.ExecException: Process 'command 'npm'' finished with non-zero exit value 1

* Full exception is:
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':foo-api:installTypeScriptDependencies'.
```

As an attempted workaround, if one tried the following:
```
generateNpmrc.registryUri = 'https://artifacts.example.com/npm/'
tasks.installTypeScriptDependencies.dependsOn tasks.generateNpmrc
```

This fails with a circular dependency.
```
FAILURE: Build failed with an exception.

* What went wrong:
Circular dependency between the following tasks:
:foo-api:compileTypeScript
\--- :foo-api:installTypeScriptDependencies
     \--- :foo-api:generateNpmrc
          \--- :foo-api:compileTypeScript (*)

(*) - details omitted (listed previously)
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
generateNpmrc task does not depend on running compileTypeScript first
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

