### PR TITLE
Remove unnecessary task dependencies

### DIFF
--- a/changelog/@unreleased/pr-1567.v2.yml
+++ b/changelog/@unreleased/pr-1567.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Remove unnecessary `./gradlew idea` support - it has been deprecated
+    for many years, please use native Gradle integration by opening with IntelliJ
+    instead.
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/1567

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -166,7 +166,6 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
         ConjurePlugin.addGeneratedToMainSourceSet(project, generateJava);
 
         project.getTasks().named("compileJava").configure(compileJava -> compileJava.dependsOn(generateJava));
-        ConjurePlugin.applyDependencyForIdeTasks(project, generateJava);
         ConjurePlugin.configureIdeGeneratedSources(
                 project, generateJava.flatMap(ConjureJavaLocalGeneratorTask::getOutputDirectory));
     }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
@@ -63,7 +63,6 @@ public final class ConjureLocalPlugin implements Plugin<Project> {
                     + "from remote Conjure definitions.");
             task.setGroup(ConjurePlugin.TASK_GROUP);
         });
-        ConjurePlugin.applyDependencyForIdeTasks(project, generateConjure);
 
         setupConjureJava(
                 project, immutableOptionsSupplier(extension::getJava), conjureIrConfiguration, generateConjure);

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Sets;
 import com.palantir.gradle.conjure.api.ConjureExtension;
 import com.palantir.gradle.conjure.api.ConjureProductDependenciesExtension;
 import com.palantir.gradle.conjure.api.GeneratorOptions;
+import com.palantir.gradle.utils.environmentvariables.EnvironmentVariables;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -120,6 +121,8 @@ public final class ConjurePlugin implements Plugin<Project> {
                     task.setDescription("Generates code for your API definitions in src/main/conjure/**/*.yml");
                     task.setGroup(TASK_GROUP);
                 });
+
+        buildDependsOn(project, compileConjure);
 
         setupConjureJavaProjects(
                 project, immutableOptionsSupplier(conjureExtension::getJava), compileConjure, compileIrTask);
@@ -402,6 +405,8 @@ public final class ConjurePlugin implements Plugin<Project> {
                             task.getOutputs().dir(srcDirectory);
                         });
 
+                buildDependsOn(project, compileTypeScript);
+
                 TaskProvider<Exec> publishTypeScript = project.getTasks()
                         .register("publishTypeScript", Exec.class, task -> {
                             task.setDescription("Runs `npm publish` to publish a TypeScript package "
@@ -678,5 +683,18 @@ public final class ConjurePlugin implements Plugin<Project> {
         } else {
             return project.getRootProject().findProject(projectName);
         }
+    }
+
+    private static void buildDependsOn(Project project, TaskProvider<?> task) {
+        EnvironmentVariables environmentVariables = project.getObjects().newInstance(EnvironmentVariables.class);
+
+        if (!environmentVariables.isCircleNode0OrLocal().get()) {
+            return;
+        }
+
+        project.getPluginManager().apply(LifecycleBasePlugin.class);
+        project.getTasks().named(LifecycleBasePlugin.BUILD_TASK_NAME).configure(build -> {
+            build.dependsOn(task);
+        });
     }
 }

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -25,7 +25,6 @@ import com.google.common.collect.Sets;
 import com.palantir.gradle.conjure.api.ConjureExtension;
 import com.palantir.gradle.conjure.api.ConjureProductDependenciesExtension;
 import com.palantir.gradle.conjure.api.GeneratorOptions;
-import com.palantir.gradle.utils.environmentvariables.EnvironmentVariables;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -56,6 +55,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaLibraryPlugin;
+import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Delete;
 import org.gradle.api.tasks.Exec;
@@ -120,9 +120,6 @@ public final class ConjurePlugin implements Plugin<Project> {
                     task.setDescription("Generates code for your API definitions in src/main/conjure/**/*.yml");
                     task.setGroup(TASK_GROUP);
                 });
-
-        applyDependencyForIdeTasks(project, compileConjure);
-        buildDependsOn(project, compileConjure);
 
         setupConjureJavaProjects(
                 project, immutableOptionsSupplier(conjureExtension::getJava), compileConjure, compileIrTask);
@@ -228,7 +225,6 @@ public final class ConjurePlugin implements Plugin<Project> {
                     });
             addGeneratedToMainSourceSet(subproj, conjureGeneratorTask);
             subproj.getTasks().named("compileJava").configure(t -> t.dependsOn(conjureGeneratorTask));
-            applyDependencyForIdeTasks(subproj, conjureGeneratorTask);
             ConjurePlugin.configureIdeGeneratedSources(
                     subproj, conjureGeneratorTask.flatMap(ConjureGeneratorTask::getOutputDirectory));
             compileConjure.configure(t -> t.dependsOn(conjureGeneratorTask));
@@ -333,7 +329,6 @@ public final class ConjurePlugin implements Plugin<Project> {
         String typescriptProjectName = project.getName() + "-typescript";
         if (derivedProjectExists(project, typescriptProjectName)) {
             project.project(derivedProjectPath(project, typescriptProjectName), subproj -> {
-                applyDependencyForIdeTasks(subproj, compileConjure);
                 File srcDirectory = subproj.file("src");
                 TaskProvider<ExtractExecutableTask> extractConjureTypeScriptTask =
                         ExtractConjurePlugin.applyConjureTypeScript(project);
@@ -407,8 +402,6 @@ public final class ConjurePlugin implements Plugin<Project> {
                             task.getOutputs().dir(srcDirectory);
                         });
 
-                buildDependsOn(project, compileTypeScript);
-
                 TaskProvider<Exec> publishTypeScript = project.getTasks()
                         .register("publishTypeScript", Exec.class, task -> {
                             task.setDescription("Runs `npm publish` to publish a TypeScript package "
@@ -453,7 +446,6 @@ public final class ConjurePlugin implements Plugin<Project> {
         String pythonProjectName = project.getName() + "-python";
         if (derivedProjectExists(project, pythonProjectName)) {
             project.project(derivedProjectPath(project, pythonProjectName), subproj -> {
-                applyDependencyForIdeTasks(subproj, compileConjure);
                 File buildDir = new File(project.getBuildDir(), "python");
                 File distDir = new File(buildDir, "dist");
                 TaskProvider<ExtractExecutableTask> extractConjurePythonTask =
@@ -597,41 +589,16 @@ public final class ConjurePlugin implements Plugin<Project> {
         return Collections.emptyMap();
     }
 
-    // TODO(fwindheuser): Replace 'JavaPluginConvention'  with 'JavaPluginExtension' after dropping Gradle 6 support.
-    @SuppressWarnings("deprecation")
     static void addGeneratedToMainSourceSet(Project subproj, TaskProvider<?> conjureGeneratorTask) {
-        org.gradle.api.plugins.JavaPluginExtension javaPlugin =
-                subproj.getExtensions().getByType(org.gradle.api.plugins.JavaPluginExtension.class);
+        JavaPluginExtension javaPlugin = subproj.getExtensions().getByType(JavaPluginExtension.class);
         javaPlugin.getSourceSets().getByName("main").getJava().srcDir(conjureGeneratorTask);
-    }
-
-    static void applyDependencyForIdeTasks(Project project, TaskProvider<?> compileConjure) {
-        project.getPlugins().withType(IdeaPlugin.class, _plugin -> {
-            // root project does not have the ideaModule task.  There is unfortunately no
-            // safe way to check for existence with the task avoidance APIs
-            try {
-                project.getTasks().named("ideaModule").configure(t -> t.dependsOn(compileConjure));
-            } catch (UnknownTaskException e) {
-                project.getLogger().debug("Project does not have ideaModule task.", e);
-            }
-        });
-
-        project.getPlugins().withType(EclipsePlugin.class, _plugin -> {
-            try {
-                project.getTasks().named("eclipseClasspath").configure(t -> t.dependsOn(compileConjure));
-            } catch (UnknownTaskException e) {
-                // eclipseClasspath is not always registered
-            }
-        });
     }
 
     static void configureIdeGeneratedSources(Project project, Provider<Directory> generated) {
         project.getPlugins().withType(IdeaPlugin.class, plugin -> {
             IdeaModule module = plugin.getModel().getModule();
 
-            // module.getSourceDirs / getGeneratedSourceDirs could be an immutable set, so defensively copy
-            module.setSourceDirs(mutableSetWithExtraEntry(
-                    module.getSourceDirs(), generated.get().getAsFile()));
+            // module.getGeneratedSourceDirs could be an immutable set, so defensively copy
             module.setGeneratedSourceDirs(mutableSetWithExtraEntry(
                     module.getGeneratedSourceDirs(), generated.get().getAsFile()));
         });
@@ -711,18 +678,5 @@ public final class ConjurePlugin implements Plugin<Project> {
         } else {
             return project.getRootProject().findProject(projectName);
         }
-    }
-
-    private static void buildDependsOn(Project project, TaskProvider<?> task) {
-        EnvironmentVariables environmentVariables = project.getObjects().newInstance(EnvironmentVariables.class);
-
-        if (!environmentVariables.isCircleNode0OrLocal().get()) {
-            return;
-        }
-
-        project.getPluginManager().apply(LifecycleBasePlugin.class);
-        project.getTasks().named(LifecycleBasePlugin.BUILD_TASK_NAME).configure(build -> {
-            build.dependsOn(task);
-        });
     }
 }

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPluginIntegrationSpec.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPluginIntegrationSpec.groovy
@@ -120,27 +120,6 @@ class ConjureJavaLocalCodegenPluginIntegrationSpec extends IntegrationSpec {
         fileExists('conjure-api/build/generated/sources/conjure-java-local-java/java/main/test/group/com/palantir/conjure/spec/ConjureDefinition.java')
     }
 
-    def 'sets up idea source sets correctly'() {
-        buildFile << """
-        conjure { java { addFlag 'objects' } }
-        subprojects {
-            apply plugin: 'idea'
-        }
-        """.stripIndent()
-        addSubproject("conjure-api")
-
-        when:
-        runTasksSuccessfully('idea')
-
-        then:
-        def slurper = new XmlParser()
-        def module = slurper.parse(file('conjure-api/conjure-api.iml'))
-        def sourcesFolderUrls = module.component.content.sourceFolder.@url
-
-        sourcesFolderUrls.size() == 1
-        sourcesFolderUrls.contains('file://$MODULE_DIR$/build/generated/sources/conjure-java-local-java/java/main')
-    }
-
     def 'embeds product dependencies correctly'() {
         addSubproject("conjure-api")
         buildFile << """

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -656,62 +656,6 @@ class ConjurePluginTest extends IntegrationSpec {
         'peer'     | ''
     }
 
-    def 'sets up idea source sets correctly'() {
-        given:
-        createFile('api/api-jersey/some-extra-source-folder')
-
-        file('build.gradle') << '''
-        subprojects {
-            apply plugin: 'idea'
-
-            idea {
-                module {
-                    sourceDirs += file('some-extra-source-folder')
-                }
-            }
-        }
-        '''.stripIndent()
-
-        when:
-        runTasksSuccessfully('idea')
-
-        then:
-        def slurper = new XmlParser()
-        def module = slurper.parse(file('api/api-jersey/api-jersey.iml'))
-        def sourcesFolderUrls = module.component.content.sourceFolder.@url
-
-        sourcesFolderUrls.size() == 2
-        sourcesFolderUrls.contains('file://$MODULE_DIR$/some-extra-source-folder')
-        sourcesFolderUrls.contains('file://$MODULE_DIR$/build/generated/sources/conjure-jersey/java/main')
-    }
-
-    def 'compileTypeScript is run on build for circle node 0'() {
-        when:
-        def stdout = runTasksSuccessfully('build', '--dry-run',
-                '-P__TESTING_CIRCLE_NODE_INDEX=0').standardOutput
-
-        then:
-        stdout.contains ':api:compileTypeScript SKIPPED'
-    }
-
-    def 'compileTypeScript is not run on build for circle node 1'() {
-        when:
-        def stdout = runTasksSuccessfully('build', '--dry-run',
-                '-P__TESTING_CIRCLE_NODE_INDEX=1').standardOutput
-
-        then:
-        !stdout.contains(':api:compileTypeScript SKIPPED')
-    }
-
-    def 'compileTypeScript is run on build locally'() {
-        when:
-        // No CIRCLE_NODE_INDEX property set means local build
-        def stdout = runTasksSuccessfully('build', '--dry-run').standardOutput
-
-        then:
-        stdout.contains ':api:compileTypeScript SKIPPED'
-    }
-
     @RestoreSystemProperties
     def 'works with checkUnusedDependencies'() {
         System.setProperty("ignoreMutableProjectStateWarnings", "true")

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -656,6 +656,33 @@ class ConjurePluginTest extends IntegrationSpec {
         'peer'     | ''
     }
 
+    def 'compileTypeScript is run on build for circle node 0'() {
+        when:
+        def stdout = runTasksSuccessfully('build', '--dry-run',
+                '-P__TESTING_CIRCLE_NODE_INDEX=0').standardOutput
+
+        then:
+        stdout.contains ':api:compileTypeScript SKIPPED'
+    }
+
+    def 'compileTypeScript is not run on build for circle node 1'() {
+        when:
+        def stdout = runTasksSuccessfully('build', '--dry-run',
+                '-P__TESTING_CIRCLE_NODE_INDEX=1').standardOutput
+
+        then:
+        !stdout.contains(':api:compileTypeScript SKIPPED')
+    }
+
+    def 'compileTypeScript is run on build locally'() {
+        when:
+        // No CIRCLE_NODE_INDEX property set means local build
+        def stdout = runTasksSuccessfully('build', '--dry-run').standardOutput
+
+        then:
+        stdout.contains ':api:compileTypeScript SKIPPED'
+    }
+
     @RestoreSystemProperties
     def 'works with checkUnusedDependencies'() {
         System.setProperty("ignoreMutableProjectStateWarnings", "true")


### PR DESCRIPTION
Motivated by internal discussions about removing `compileConjureTypeScript` and `installTypeScriptDependencies` from the build task graph when the outputs aren't actually needed.

Admittedly, it is a bit weird that these projects won't be build as part of the lifecycle tasks. But even if we want that, `build` is the wrong task to use - these should be dependencies of `assemble`. The subprojects will already be part of `assemble` as a result of any language-specific plugins applied to those subproject (ie. the Java plugin).

This PR also remove the IDE task dependencies. Opening projects using the IDEA plugin is deprecated and no longer used, so we don't need these tasks. We do however still need to declared the source directories as generated source directories in IntelliJ.