### PR TITLE
Add validation-api dependency to jersey projects when using NotNull

### DIFF
--- a/changelog/@unreleased/pr-1648.v2.yml
+++ b/changelog/@unreleased/pr-1648.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Add validation-api dependency to jersey projects when using NotNull
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/1648

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -117,6 +117,14 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
         if (Dependencies.isJersey(extension.getJava())) {
             project.getDependencies()
                     .add("api", useJakarta ? Dependencies.JAXRS_API_JAKARTA : Dependencies.JAXRS_API_JAVAX);
+            if (Dependencies.isNotNullAuthAndBodyParams(extension.getJava())) {
+                project.getDependencies()
+                        .add(
+                                "implementation",
+                                useJakarta
+                                        ? Dependencies.JAXRS_VALIDATION_API_JAKARTA
+                                        : Dependencies.JAXRS_VALIDATION_API_JAVAX);
+            }
         }
         if (Dependencies.isDialogue(extension.getJava())) {
             project.getDependencies().add("api", Dependencies.DIALOGUE_TARGET);

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -288,6 +288,14 @@ public final class ConjurePlugin implements Plugin<Project> {
         boolean useJakarta = Dependencies.isJakartaPackages(optionsSupplier.get());
         project.getDependencies()
                 .add("api", useJakarta ? Dependencies.JAXRS_API_JAKARTA : Dependencies.JAXRS_API_JAVAX);
+        if (Dependencies.isNotNullAuthAndBodyParams(optionsSupplier.get())) {
+            project.getDependencies()
+                    .add(
+                            "implementation",
+                            useJakarta
+                                    ? Dependencies.JAXRS_VALIDATION_API_JAKARTA
+                                    : Dependencies.JAXRS_VALIDATION_API_JAVAX);
+        }
         project.getDependencies()
                 .add(
                         "compileOnly",

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/Dependencies.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/Dependencies.java
@@ -25,6 +25,8 @@ final class Dependencies {
     static final String ANNOTATION_API_JAVAX = "javax.annotation:javax.annotation-api:1.3.2";
     static final String JAXRS_API_JAKARTA = "jakarta.ws.rs:jakarta.ws.rs-api:3.0.0";
     static final String JAXRS_API_JAVAX = "javax.ws.rs:javax.ws.rs-api:2.1.1";
+    static final String JAXRS_VALIDATION_API_JAKARTA = "jakarta.validation:jakarta.validation-api:3.0.0";
+    static final String JAXRS_VALIDATION_API_JAVAX = "javax.validation:validation-api:2.0.1.Final";
 
     static final String CONJURE_JAVA_LIB = "com.palantir.conjure.java:conjure-lib:8.22.0";
     static final String CONJURE_UNDERTOW_LIB = "com.palantir.conjure.java:conjure-undertow-lib:8.22.0";
@@ -36,24 +38,37 @@ final class Dependencies {
     static final String JETBRAINS_ANNOTATIONS = "org.jetbrains:annotations:23.0.0";
 
     private static final String JAKARTA_PACKAGES = "jakartaPackages";
+    private static final String REQUIRE_NOT_NULL_AUTH_AND_BODY_PARAMS = "requireNotNullAuthAndBodyParams";
     private static final String JERSEY = "jersey";
     private static final String DIALOGUE = "dialogue";
     private static final String UNDERTOW = "undertow";
 
     static boolean isJakartaPackages(GeneratorOptions options) {
-        return options.has(JAKARTA_PACKAGES) && Boolean.TRUE.equals(options.get(JAKARTA_PACKAGES));
+        return isOption(options, JAKARTA_PACKAGES);
+    }
+
+    /**
+     * See
+     * https://github.com/palantir/conjure-java/blob/bd3dce573b5d92f6efd29f30a7c013f779030c91/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java#L37-L44.
+     */
+    static boolean isNotNullAuthAndBodyParams(GeneratorOptions options) {
+        return isOption(options, REQUIRE_NOT_NULL_AUTH_AND_BODY_PARAMS);
     }
 
     static boolean isJersey(GeneratorOptions options) {
-        return options.has(JERSEY) && Boolean.TRUE.equals(options.get(JERSEY));
+        return isOption(options, JERSEY);
     }
 
     static boolean isDialogue(GeneratorOptions options) {
-        return options.has(DIALOGUE) && Boolean.TRUE.equals(options.get(DIALOGUE));
+        return isOption(options, DIALOGUE);
     }
 
     static boolean isUndertow(GeneratorOptions options) {
-        return options.has(UNDERTOW) && Boolean.TRUE.equals(options.get(UNDERTOW));
+        return isOption(options, UNDERTOW);
+    }
+
+    private static boolean isOption(GeneratorOptions options, String optionName) {
+        return options.has(optionName) && Boolean.TRUE.equals(options.get(optionName));
     }
 
     private Dependencies() {}

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -159,6 +159,71 @@ class ConjurePluginTest extends IntegrationSpec {
         'peer'     | ''
     }
 
+    def 'check code compiles with requireNotNullAuthAndBodyParams: #location'() {
+        setup:
+        updateSettings(prefix)
+
+        // language=gradle
+        file('api/build.gradle') << """
+        conjure {
+            java {
+                requireNotNullAuthAndBodyParams = true
+            }
+        }
+        """.stripIndent()
+
+        when:
+        ExecutionResult result = runTasksSuccessfully('compileJava')
+
+        then:
+        result.wasExecuted(prefixProject(prefix, 'api-objects:compileJava'))
+        result.wasExecuted(':api:compileConjureObjects')
+        result.wasExecuted(prefixProject(prefix, 'api-jersey:compileJava'))
+        result.wasExecuted(':api:compileConjureJersey')
+        result.wasExecuted(prefixProject(prefix, 'api-undertow:compileJava'))
+        result.wasExecuted(':api:compileConjureUndertow')
+        result.wasExecuted(prefixProject(prefix, 'api-dialogue:compileJava'))
+        result.wasExecuted(':api:compileConjureDialogue')
+
+        where:
+        location   | prefix
+        'sub'      | 'api'
+        'peer'     | ''
+    }
+
+    def 'check code compiles with requireNotNullAuthAndBodyParams and jakarta: #location'() {
+        setup:
+        updateSettings(prefix)
+
+        // language=gradle
+        file('api/build.gradle') << """
+        conjure {
+            java {
+                requireNotNullAuthAndBodyParams = true
+                jakartaPackages = true
+            }
+        }
+        """.stripIndent()
+
+        when:
+        ExecutionResult result = runTasksSuccessfully('compileJava')
+
+        then:
+        result.wasExecuted(prefixProject(prefix, 'api-objects:compileJava'))
+        result.wasExecuted(':api:compileConjureObjects')
+        result.wasExecuted(prefixProject(prefix, 'api-jersey:compileJava'))
+        result.wasExecuted(':api:compileConjureJersey')
+        result.wasExecuted(prefixProject(prefix, 'api-undertow:compileJava'))
+        result.wasExecuted(':api:compileConjureUndertow')
+        result.wasExecuted(prefixProject(prefix, 'api-dialogue:compileJava'))
+        result.wasExecuted(':api:compileConjureDialogue')
+
+        where:
+        location   | prefix
+        'sub'      | 'api'
+        'peer'     | ''
+    }
+
     def 'check cache is used: #location'() {
         setup:
         updateSettings(prefix)


### PR DESCRIPTION
## Before this PR
When using [`requireNotNullAuthAndBodyParams`](https://github.com/palantir/conjure-java/blob/bd3dce573b5d92f6efd29f30a7c013f779030c91/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java#L37-L44) and generating the jersey subprojects, this would use `javax.validation.constraints.NotNull` (if using javax) or `jakarta.validation.constraints.NotNull` (if using jakarta)

However, we would not be adding the dependency to the jersey subproject, which would cause a compilation failure, and require users to manually add the dependency to their project.

## After this PR
==COMMIT_MSG==
Add validation-api dependency to jersey projects when using NotNull
==COMMIT_MSG==

## Possible downsides?


