### PR TITLE
Share dependency setup between normal and local conjure generation plugins

### DIFF
--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPlugin.java
@@ -115,22 +115,13 @@ public final class ConjureJavaLocalCodegenPlugin implements Plugin<Project> {
                         "compileOnly",
                         useJakarta ? Dependencies.ANNOTATION_API_JAKARTA : Dependencies.ANNOTATION_API_JAVAX);
         if (Dependencies.isJersey(extension.getJava())) {
-            project.getDependencies()
-                    .add("api", useJakarta ? Dependencies.JAXRS_API_JAKARTA : Dependencies.JAXRS_API_JAVAX);
-            if (Dependencies.isNotNullAuthAndBodyParams(extension.getJava())) {
-                project.getDependencies()
-                        .add(
-                                "implementation",
-                                useJakarta
-                                        ? Dependencies.JAXRS_VALIDATION_API_JAKARTA
-                                        : Dependencies.JAXRS_VALIDATION_API_JAVAX);
-            }
+            ConjurePlugin.setupJerseyProject(project, extension::getJava);
         }
         if (Dependencies.isDialogue(extension.getJava())) {
-            project.getDependencies().add("api", Dependencies.DIALOGUE_TARGET);
+            ConjurePlugin.setupDialogueProject(project, extension::getJava);
         }
         if (Dependencies.isUndertow(extension.getJava())) {
-            project.getDependencies().add("api", Dependencies.CONJURE_UNDERTOW_LIB);
+            ConjurePlugin.setupUndertowProject(project, extension::getJava);
         }
     }
 

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -280,11 +280,11 @@ public final class ConjurePlugin implements Plugin<Project> {
         project.getDependencies().add("api", Dependencies.JETBRAINS_ANNOTATIONS);
     }
 
-    private static void setupDialogueProject(Project project, Supplier<GeneratorOptions> _optionsSupplier) {
+    static void setupDialogueProject(Project project, Supplier<GeneratorOptions> _optionsSupplier) {
         project.getDependencies().add("api", Dependencies.DIALOGUE_TARGET);
     }
 
-    private static void setupJerseyProject(Project project, Supplier<GeneratorOptions> optionsSupplier) {
+    static void setupJerseyProject(Project project, Supplier<GeneratorOptions> optionsSupplier) {
         boolean useJakarta = Dependencies.isJakartaPackages(optionsSupplier.get());
         project.getDependencies()
                 .add("api", useJakarta ? Dependencies.JAXRS_API_JAKARTA : Dependencies.JAXRS_API_JAVAX);
@@ -302,7 +302,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                         useJakarta ? Dependencies.ANNOTATION_API_JAKARTA : Dependencies.ANNOTATION_API_JAVAX);
     }
 
-    private static void setupUndertowProject(Project project, Supplier<GeneratorOptions> _optionsSupplier) {
+    static void setupUndertowProject(Project project, Supplier<GeneratorOptions> _optionsSupplier) {
         project.getDependencies().add("api", Dependencies.CONJURE_UNDERTOW_LIB);
     }
 


### PR DESCRIPTION
## Before this PR
Follow-up on https://github.com/palantir/gradle-conjure/pull/1648

I realized that we had somewhat duplicated logic for setting up the dependencies on a conjure subproject, between the normal plugin and the conjure-java-local one.

It turns out that at least parts could be shared

## After this PR
==COMMIT_MSG==
Share dependency setup between normal and local conjure generation plugins
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

