### PR TITLE
Support setting boolean Conjure CLI flags with true values

### DIFF
--- a/changelog/@unreleased/pr-1678.v2.yml
+++ b/changelog/@unreleased/pr-1678.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Support setting boolean Conjure CLI flags with true values
+  links:
+  - https://github.com/palantir/gradle-conjure/pull/1678

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/RenderGeneratorOptions.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/RenderGeneratorOptions.java
@@ -61,9 +61,6 @@ public final class RenderGeneratorOptions {
                 .sorted(Comparator.comparing(Map.Entry::getKey))
                 .map(entry -> {
                     Object value = entry.getValue();
-                    if (value == Boolean.TRUE) {
-                        return "--" + entry.getKey();
-                    }
                     Preconditions.checkArgument(
                             !entry.getKey().contains("="),
                             "Conjure generator parameter '%s' cannot contain '='",

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPluginIntegrationSpec.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureJavaLocalCodegenPluginIntegrationSpec.groovy
@@ -81,8 +81,8 @@ class ConjureJavaLocalCodegenPluginIntegrationSpec extends ConfigurationCacheSpe
         result.tasks(TaskOutcome.SUCCESS)*.path.containsAll(':extractConjureIr', ':conjure-api:generateConjure')
         fileExists("build/conjure-ir/conjure-api.conjure.json")
         fileExists('conjure-api/build/generated/sources/conjure-java-local-java/java/main/test/groupwithdashes/com/palantir/conjure/spec/ConjureDefinition.java')
-        result.output.contains "with args: [--jersey, --jetbrainsContractAnnotations, --packagePrefix=test.groupwithdashes]"
-        result.output.contains "with args: [--jetbrainsContractAnnotations, --objects, --packagePrefix=test.groupwithdashes]"
+        result.output.contains "with args: [--jersey=true, --jetbrainsContractAnnotations=true, --packagePrefix=test.groupwithdashes]"
+        result.output.contains "with args: [--jetbrainsContractAnnotations=true, --objects=true, --packagePrefix=test.groupwithdashes]"
     }
 
     def "respects user provided packagePrefix"() {
@@ -102,7 +102,7 @@ class ConjureJavaLocalCodegenPluginIntegrationSpec extends ConfigurationCacheSpe
         then:
         result.tasks(TaskOutcome.SUCCESS)*.path.contains(":extractConjureIr")
         fileExists('conjure-api/build/generated/sources/conjure-java-local-java/java/main/user/group/com/palantir/conjure/spec/ConjureDefinition.java')
-        result.output.contains "with args: [--jetbrainsContractAnnotations, --objects, --packagePrefix=user.group]"
+        result.output.contains "with args: [--jetbrainsContractAnnotations=true, --objects=true, --packagePrefix=user.group]"
     }
 
     def 'check code compiles'() {

--- a/gradle-conjure/src/test/java/com/palantir/gradle/conjure/RenderGeneratorOptionsTest.java
+++ b/gradle-conjure/src/test/java/com/palantir/gradle/conjure/RenderGeneratorOptionsTest.java
@@ -31,7 +31,7 @@ public class RenderGeneratorOptionsTest {
         generatorOptions.setProperty("foo", true);
         generatorOptions.setProperty("bar", false);
         assertThat(RenderGeneratorOptions.toArgs(generatorOptions, ImmutableMap.of()))
-                .containsExactly("--bar=false", "--foo");
+                .containsExactly("--bar=false", "--foo=true");
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
Currently, when a boolean Conjure CLI flag is set with the value `true`, `gradle-conjure` passes in the flag without a value (e.g. `--flag` instead of `--flag=true`). 

When a flag has a default value of `true`, setting the value of the flag to `true` in the Conjure Gradle block will result in `gradle-conjure` passing in `--flag` which toggles the value to `false`. This is counterintuitive.

I tested this behavior of picocli with this small experiment using picocli-4.6.2:

```java
import picocli.CommandLine;
import picocli.CommandLine.Command;
import picocli.CommandLine.Option;

@Command
class BooleanFlagTest implements Runnable {
    
    @Option(names = "--default-false", defaultValue = "false")
    boolean defaultFalse = false;

    @Option(names = "--default-true", defaultValue = "true")
    boolean defaultTrue = true;

    public void run() {
        System.out.println("DefaultFalse value: " + defaultFalse);
        System.out.println("DefaultTrue value: " + defaultTrue);
    }

    public static void main(String[] args) {
        new CommandLine(new BooleanFlagTest()).execute(args);
    }
}
```

```bash
▶ java -cp <path-to-picocli-jar>:. BooleanFlagTest --default-true
DefaultFalse value: false
DefaultTrue value: false

▶ java -cp <path-to-picocli-jar>:. BooleanFlagTest --default-true=true --default-false=true
DefaultFalse value: true
DefaultTrue value: true

▶ java -cp <path-to-picocli-jar>:. BooleanFlagTest --default-true=false --default-false=false
DefaultFalse value: false
DefaultTrue value: false
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Support setting boolean Conjure CLI flags with true values
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

