### PR TITLE
Disable `JavaCompile` tasks on conjure typescript subprojects

### DIFF
--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -63,6 +63,7 @@ import org.gradle.api.tasks.Delete;
 import org.gradle.api.tasks.Exec;
 import org.gradle.api.tasks.TaskOutputs;
 import org.gradle.api.tasks.TaskProvider;
+import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.plugins.ide.eclipse.EclipsePlugin;
 import org.gradle.plugins.ide.eclipse.model.Classpath;
@@ -426,6 +427,9 @@ public final class ConjurePlugin implements Plugin<Project> {
                         });
 
                 buildDependsOn(project, compileTypeScript);
+
+                // Disable any JavaCompile tasks on the typescript subproject — it has no Java sources
+                subproj.getTasks().withType(JavaCompile.class).configureEach(task -> task.setEnabled(false));
 
                 @SuppressWarnings("for-rollout:TaskDependsOn")
                 TaskProvider<Exec> publishTypeScript = project.getTasks()

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -770,6 +770,22 @@ class ConjurePluginTest extends ConfigurationCacheSpec implements FileExists {
         runTasks('checkUnusedDependencies', '--warning-mode=all')
     }
 
+    def 'typescript subproject compileJava is disabled when java-library is applied'() {
+        setup:
+        buildFile << """
+            project(':api:api-typescript') {
+                apply plugin: 'java-library'
+            }
+        """.stripIndent()
+
+        when:
+        BuildResult result = runTasksWithConfigurationCacheAndCheck(
+                ':api:api-typescript:compileJava')
+
+        then:
+        result.task(':api:api-typescript:compileJava').outcome == TaskOutcome.SKIPPED
+    }
+
     @IgnoreIf({ jvm.java11Compatible })
     def 'runs on version of gradle: #version'() {
         when:


### PR DESCRIPTION
## Before this PR

Many repos apply `java-library` broadly to subprojects, which inadvertently gives the conjure typescript subproject a `compileJava` task:
```groovy
subprojects {
    apply plugin: 'java-library'  // also applies to :foo-api:foo-api-typescript
}
```

The conjure plugin declares the typescript subproject's `src/` directory as an output of `compileTypeScript`/`compileConjureTypeScript`. When `java-library` is also applied, the `compileJava` task gets a source directory under `src/` that overlaps with these outputs — and `compileJava` is **not** NO-SOURCE (build scans show it actually executes with a resolved Java toolchain), because the TypeScript generator populates the `src/` tree.

Since `compileJava` actually runs, Gradle fingerprints its inputs, which triggers the consumer-side implicit dependency check in [`MissingTaskDependencyDetector`](https://github.com/gradle/gradle/pull/31293). This detects the overlap as an [implicit dependency](https://docs.gradle.org/9.4.0/userguide/validation_problems.html#implicit_dependency) error:
```
Task ':api:api-typescript:compileJava' uses this output of task ':api:compileTypeScript'
without declaring an explicit or implicit dependency.
```

This only fails **intermittently** because the check compares against tasks that have already been executed — `compileJava` only fails if `compileTypeScript` has already registered its outputs earlier in the build. On CI with parallel execution and different caching, the task order varies between runs.

Some repos work around this at the API level by excluding typescript from `publish-jar`:
```groovy
configure(subprojects.findAll { !it.name.endsWith('-typescript') }) {
    apply plugin: 'com.palantir.publish-jar'
}
```
But every affected repo migrating to Gradle 9 would need to independently discover and patch around this.

==CHANGELOG_MSG==
Disable `JavaCompile` tasks on conjure typescript subprojects to fix Gradle 9 implicit dependency errors when consumer repos apply `java-library` to all subprojects.
==CHANGELOG_MSG==

## After this PR

The plugin disables `JavaCompile` tasks on the typescript subproject via `withType(JavaCompile.class)`. The typescript subproject has no Java sources (confirmed across all internal repos), so these tasks are useless. This fixes the problem at source rather than requiring every consumer repo to exclude the typescript subproject.

Verified that disabling the task is sufficient — Gradle 9 skips the validation for disabled tasks.

## Possible downsides?

## Testing

Test applies `java-library` to the typescript subproject and verifies `compileJava` is `SKIPPED`. Confirmed failing without the fix and passing with it.