### PR TITLE
Move conjure TypeScript output from `src/` to `build/generated/sources/`

### DIFF
--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
@@ -247,7 +247,7 @@ public final class ConjureLocalPlugin implements Plugin<Project> {
                             .set(extractConjureTypeScriptTask.flatMap(ExtractExecutableTask::getExecutable));
                     task.setOptions(() -> optionsSupplier.get().addFlag("rawSource"));
                     task.getOutputDirectory()
-                            .set(project.getLayout().getBuildDirectory().dir("generated/sources/conjure-typescript"));
+                            .set(subproj.getLayout().getBuildDirectory().dir("generated/sources/conjure-typescript"));
                     task.dependsOn(extractConjureTypeScriptTask);
                 });
         generateConjure.configure(t -> t.dependsOn(conjureLocalGenerateTask));

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
@@ -234,8 +234,6 @@ public final class ConjureLocalPlugin implements Plugin<Project> {
         if (subproj == null) {
             return;
         }
-        File srcDirectory = subproj.file("src");
-
         TaskProvider<ExtractExecutableTask> extractConjureTypeScriptTask =
                 ExtractConjurePlugin.applyConjureTypeScript(project);
 
@@ -248,7 +246,8 @@ public final class ConjureLocalPlugin implements Plugin<Project> {
                     task.getExecutablePath()
                             .set(extractConjureTypeScriptTask.flatMap(ExtractExecutableTask::getExecutable));
                     task.setOptions(() -> optionsSupplier.get().addFlag("rawSource"));
-                    task.getOutputDirectory().set(srcDirectory);
+                    task.getOutputDirectory()
+                            .set(project.getLayout().getBuildDirectory().dir("generated/sources/conjure-typescript"));
                     task.dependsOn(extractConjureTypeScriptTask);
                 });
         generateConjure.configure(t -> t.dependsOn(conjureLocalGenerateTask));

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -344,7 +344,7 @@ public final class ConjurePlugin implements Plugin<Project> {
         if (derivedProjectExists(project, typescriptProjectName)) {
             project.project(derivedProjectPath(project, typescriptProjectName), subproj -> {
                 Provider<Directory> tsOutputDir =
-                        project.getLayout().getBuildDirectory().dir("generated/sources/conjure-typescript");
+                        subproj.getLayout().getBuildDirectory().dir("generated/sources/conjure-typescript");
                 TaskProvider<ExtractExecutableTask> extractConjureTypeScriptTask =
                         ExtractConjurePlugin.applyConjureTypeScript(project);
                 @SuppressWarnings("for-rollout:TaskDependsOn")
@@ -397,10 +397,8 @@ public final class ConjurePlugin implements Plugin<Project> {
                                     .set(List.of(npmCommand, "install", "--no-package-lock", "--no-production"));
                             task.getWorkingDir().set(tsOutputDir.map(Directory::getAsFile));
                             task.dependsOn(compileConjureTypeScript);
-                            task.getInputs()
-                                    .file(tsOutputDir.map(dir -> dir.file("package.json")));
-                            task.getOutputs()
-                                    .dir(tsOutputDir.map(dir -> dir.dir("node_modules")));
+                            task.getInputs().file(tsOutputDir.map(dir -> dir.file("package.json")));
+                            task.getOutputs().dir(tsOutputDir.map(dir -> dir.dir("node_modules")));
                         });
                 installTypeScriptDependencies.configure(task -> {
                     if (Boolean.parseBoolean(options.get()

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -343,7 +343,7 @@ public final class ConjurePlugin implements Plugin<Project> {
         String typescriptProjectName = project.getName() + "-typescript";
         if (derivedProjectExists(project, typescriptProjectName)) {
             project.project(derivedProjectPath(project, typescriptProjectName), subproj -> {
-                Provider<Directory> tsOutputDir =
+                Provider<Directory> outputDirectory =
                         subproj.getLayout().getBuildDirectory().dir("generated/sources/conjure-typescript");
                 TaskProvider<ExtractExecutableTask> extractConjureTypeScriptTask =
                         ExtractConjurePlugin.applyConjureTypeScript(project);
@@ -363,7 +363,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                             task.getProductDependencyFile()
                                     .set(productDependencyTask.flatMap(
                                             GenerateConjureServiceDependenciesTask::getOutputFile));
-                            task.getOutputDirectory().set(tsOutputDir);
+                            task.getOutputDirectory().set(outputDirectory);
                             task.setOptions(options);
                             task.dependsOn(extractConjureTypeScriptTask, productDependencyTask, compileIrTask);
                         });
@@ -395,10 +395,10 @@ public final class ConjurePlugin implements Plugin<Project> {
                         .register("installTypeScriptDependencies", BetterExec.class, task -> {
                             task.getCommand()
                                     .set(List.of(npmCommand, "install", "--no-package-lock", "--no-production"));
-                            task.getWorkingDir().set(tsOutputDir.map(Directory::getAsFile));
+                            task.getWorkingDir().set(outputDirectory.map(Directory::getAsFile));
                             task.dependsOn(compileConjureTypeScript);
-                            task.getInputs().file(tsOutputDir.map(dir -> dir.file("package.json")));
-                            task.getOutputs().dir(tsOutputDir.map(dir -> dir.dir("node_modules")));
+                            task.getInputs().file(outputDirectory.map(dir -> dir.file("package.json")));
+                            task.getOutputs().dir(outputDirectory.map(dir -> dir.dir("node_modules")));
                         });
                 installTypeScriptDependencies.configure(task -> {
                     if (Boolean.parseBoolean(options.get()
@@ -419,9 +419,9 @@ public final class ConjurePlugin implements Plugin<Project> {
                                     "Runs `npm tsc` to compile generated TypeScript files into JavaScript files.");
                             task.setGroup(TASK_GROUP);
                             task.getCommand().set(List.of(npmCommand, "run-script", "build"));
-                            task.getWorkingDir().set(tsOutputDir.map(Directory::getAsFile));
+                            task.getWorkingDir().set(outputDirectory.map(Directory::getAsFile));
                             task.dependsOn(installTypeScriptDependencies);
-                            task.getOutputs().dir(tsOutputDir);
+                            task.getOutputs().dir(outputDirectory);
                         });
 
                 buildDependsOn(project, compileTypeScript);
@@ -433,7 +433,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                                     + "generated from your Conjure definitions.");
                             task.setGroup(TASK_GROUP);
                             task.commandLine(npmCommand, "publish");
-                            task.workingDir(tsOutputDir.map(Directory::getAsFile));
+                            task.workingDir(outputDirectory.map(Directory::getAsFile));
                             task.dependsOn(compileConjureTypeScript);
                             task.dependsOn(compileTypeScript);
                         });

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -63,7 +63,6 @@ import org.gradle.api.tasks.Delete;
 import org.gradle.api.tasks.Exec;
 import org.gradle.api.tasks.TaskOutputs;
 import org.gradle.api.tasks.TaskProvider;
-import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.plugins.ide.eclipse.EclipsePlugin;
 import org.gradle.plugins.ide.eclipse.model.Classpath;
@@ -344,7 +343,8 @@ public final class ConjurePlugin implements Plugin<Project> {
         String typescriptProjectName = project.getName() + "-typescript";
         if (derivedProjectExists(project, typescriptProjectName)) {
             project.project(derivedProjectPath(project, typescriptProjectName), subproj -> {
-                File srcDirectory = subproj.file("src");
+                Provider<Directory> tsOutputDir =
+                        project.getLayout().getBuildDirectory().dir("generated/sources/conjure-typescript");
                 TaskProvider<ExtractExecutableTask> extractConjureTypeScriptTask =
                         ExtractConjurePlugin.applyConjureTypeScript(project);
                 @SuppressWarnings("for-rollout:TaskDependsOn")
@@ -363,10 +363,8 @@ public final class ConjurePlugin implements Plugin<Project> {
                             task.getProductDependencyFile()
                                     .set(productDependencyTask.flatMap(
                                             GenerateConjureServiceDependenciesTask::getOutputFile));
-                            task.getOutputDirectory().set(srcDirectory);
+                            task.getOutputDirectory().set(tsOutputDir);
                             task.setOptions(options);
-                            task.dependsOn(createWriteGitignoreTask(
-                                    subproj, "gitignoreConjureTypeScript", subproj.getProjectDir(), "/src/\n"));
                             task.dependsOn(extractConjureTypeScriptTask, productDependencyTask, compileIrTask);
                         });
                 compileConjure.configure(t -> t.dependsOn(compileConjureTypeScript));
@@ -397,10 +395,12 @@ public final class ConjurePlugin implements Plugin<Project> {
                         .register("installTypeScriptDependencies", BetterExec.class, task -> {
                             task.getCommand()
                                     .set(List.of(npmCommand, "install", "--no-package-lock", "--no-production"));
-                            task.getWorkingDir().set(srcDirectory);
+                            task.getWorkingDir().set(tsOutputDir.map(Directory::getAsFile));
                             task.dependsOn(compileConjureTypeScript);
-                            task.getInputs().file(new File(srcDirectory, "package.json"));
-                            task.getOutputs().dir(new File(srcDirectory, "node_modules"));
+                            task.getInputs()
+                                    .file(tsOutputDir.map(dir -> dir.file("package.json")));
+                            task.getOutputs()
+                                    .dir(tsOutputDir.map(dir -> dir.dir("node_modules")));
                         });
                 installTypeScriptDependencies.configure(task -> {
                     if (Boolean.parseBoolean(options.get()
@@ -421,15 +421,12 @@ public final class ConjurePlugin implements Plugin<Project> {
                                     "Runs `npm tsc` to compile generated TypeScript files into JavaScript files.");
                             task.setGroup(TASK_GROUP);
                             task.getCommand().set(List.of(npmCommand, "run-script", "build"));
-                            task.getWorkingDir().set(srcDirectory);
+                            task.getWorkingDir().set(tsOutputDir.map(Directory::getAsFile));
                             task.dependsOn(installTypeScriptDependencies);
-                            task.getOutputs().dir(srcDirectory);
+                            task.getOutputs().dir(tsOutputDir);
                         });
 
                 buildDependsOn(project, compileTypeScript);
-
-                // Disable any JavaCompile tasks on the typescript subproject — it has no Java sources
-                subproj.getTasks().withType(JavaCompile.class).configureEach(task -> task.setEnabled(false));
 
                 @SuppressWarnings("for-rollout:TaskDependsOn")
                 TaskProvider<Exec> publishTypeScript = project.getTasks()
@@ -438,7 +435,7 @@ public final class ConjurePlugin implements Plugin<Project> {
                                     + "generated from your Conjure definitions.");
                             task.setGroup(TASK_GROUP);
                             task.commandLine(npmCommand, "publish");
-                            task.workingDir(srcDirectory);
+                            task.workingDir(tsOutputDir.map(Directory::getAsFile));
                             task.dependsOn(compileConjureTypeScript);
                             task.dependsOn(compileTypeScript);
                         });

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalPluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalPluginTest.groovy
@@ -104,7 +104,7 @@ class ConjureLocalPluginTest extends ConfigurationCacheSpec implements FileExist
         then:
         result.tasks(TaskOutcome.SUCCESS)*.path.containsAll(":generateTypeScript", ":generatePython")
 
-        fileExists('typescript/src/conjure-api/index.ts')
+        fileExists('typescript/build/generated/sources/conjure-typescript/conjure-api/index.ts')
         fileExists('python/python/conjure-api/conjure_spec/__init__.py')
     }
 

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -119,10 +119,10 @@ class ConjurePluginTest extends ConfigurationCacheSpec implements FileExists {
         file(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/java/main/test/test/api/StringExample.java')).text.contains('ignoreUnknown')
 
         // typescript
-        fileExists('api/build/generated/sources/conjure-typescript/api/index.ts')
-        fileExists('api/build/generated/sources/conjure-typescript/index.ts')
-        fileExists('api/build/generated/sources/conjure-typescript/tsconfig.json')
-        fileExists('api/build/generated/sources/conjure-typescript/package.json')
+        fileExists( prefixPath(prefix, 'api-typescript/build/generated/sources/conjure-typescript/api/index.ts'))
+        fileExists( prefixPath(prefix, 'api-typescript/build/generated/sources/conjure-typescript/index.ts'))
+        fileExists( prefixPath(prefix, 'api-typescript/build/generated/sources/conjure-typescript/tsconfig.json'))
+        fileExists( prefixPath(prefix, 'api-typescript/build/generated/sources/conjure-typescript/package.json'))
 
         // irFile - these are always in api project
         fileExists('api/build/conjure-ir/api.conjure.json')
@@ -484,7 +484,7 @@ class ConjurePluginTest extends ConfigurationCacheSpec implements FileExists {
         fileExists( prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/java/main/test/api/internal/InternalImport.java'))
 
         // typescript
-        file('api/build/generated/sources/conjure-typescript/service/testServiceFoo2.ts').text.contains(
+        file(prefixPath(prefix, 'api-typescript/build/generated/sources/conjure-typescript/service/testServiceFoo2.ts')).text.contains(
                 'import { IInternalImport }')
 
         // ir
@@ -617,9 +617,9 @@ class ConjurePluginTest extends ConfigurationCacheSpec implements FileExists {
         runTasksWithConfigurationCache(':api:compileConjureTypeScript')
 
         then:
-        file('api/build/generated/sources/conjure-typescript/package.json').text.contains('"name": "foo"')
-        file('api/build/generated/sources/conjure-typescript/package.json').text.contains('"version": "0.0.0"')
-        file('api/build/generated/sources/conjure-typescript/tsconfig.json').text.contains('"module": "commonjs"')
+        file(prefixPath(prefix, 'api-typescript/build/generated/sources/conjure-typescript/package.json')).text.contains('"name": "foo"')
+        file(prefixPath(prefix, 'api-typescript/build/generated/sources/conjure-typescript/package.json')).text.contains('"version": "0.0.0"')
+        file(prefixPath(prefix, 'api-typescript/build/generated/sources/conjure-typescript/tsconfig.json')).text.contains('"module": "commonjs"')
 
         where:
         location   | prefix

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -119,12 +119,10 @@ class ConjurePluginTest extends ConfigurationCacheSpec implements FileExists {
         file(prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/java/main/test/test/api/StringExample.java')).text.contains('ignoreUnknown')
 
         // typescript
-        fileExists( prefixPath(prefix, 'api-typescript/src/api/index.ts'))
-        fileExists( prefixPath(prefix, 'api-typescript/src/index.ts'))
-        fileExists( prefixPath(prefix, 'api-typescript/src/tsconfig.json'))
-        fileExists( prefixPath(prefix, 'api-typescript/src/package.json'))
-        fileExists( prefixPath(prefix, 'api-typescript/.gitignore'))
-        file(prefixPath(prefix, 'api-typescript/.gitignore')).readLines() == ["/src/"]
+        fileExists('api/build/generated/sources/conjure-typescript/api/index.ts')
+        fileExists('api/build/generated/sources/conjure-typescript/index.ts')
+        fileExists('api/build/generated/sources/conjure-typescript/tsconfig.json')
+        fileExists('api/build/generated/sources/conjure-typescript/package.json')
 
         // irFile - these are always in api project
         fileExists('api/build/conjure-ir/api.conjure.json')
@@ -486,7 +484,7 @@ class ConjurePluginTest extends ConfigurationCacheSpec implements FileExists {
         fileExists( prefixPath(prefix, 'api-objects/build/generated/sources/conjure-objects/java/main/test/api/internal/InternalImport.java'))
 
         // typescript
-        file(prefixPath(prefix, 'api-typescript/src/service/testServiceFoo2.ts')).text.contains(
+        file('api/build/generated/sources/conjure-typescript/service/testServiceFoo2.ts').text.contains(
                 'import { IInternalImport }')
 
         // ir
@@ -619,9 +617,9 @@ class ConjurePluginTest extends ConfigurationCacheSpec implements FileExists {
         runTasksWithConfigurationCache(':api:compileConjureTypeScript')
 
         then:
-        file(prefixPath(prefix, 'api-typescript/src/package.json')).text.contains('"name": "foo"')
-        file(prefixPath(prefix, 'api-typescript/src/package.json')).text.contains('"version": "0.0.0"')
-        file(prefixPath(prefix, 'api-typescript/src/tsconfig.json')).text.contains('"module": "commonjs"')
+        file('api/build/generated/sources/conjure-typescript/package.json').text.contains('"name": "foo"')
+        file('api/build/generated/sources/conjure-typescript/package.json').text.contains('"version": "0.0.0"')
+        file('api/build/generated/sources/conjure-typescript/tsconfig.json').text.contains('"module": "commonjs"')
 
         where:
         location   | prefix
@@ -768,22 +766,6 @@ class ConjurePluginTest extends ConfigurationCacheSpec implements FileExists {
 
         expect:
         runTasks('checkUnusedDependencies', '--warning-mode=all')
-    }
-
-    def 'typescript subproject compileJava is disabled when java-library is applied'() {
-        setup:
-        buildFile << """
-            project(':api:api-typescript') {
-                apply plugin: 'java-library'
-            }
-        """.stripIndent()
-
-        when:
-        BuildResult result = runTasksWithConfigurationCacheAndCheck(
-                ':api:api-typescript:compileJava')
-
-        then:
-        result.task(':api:api-typescript:compileJava').outcome == TaskOutcome.SKIPPED
     }
 
     @IgnoreIf({ jvm.java11Compatible })

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePublishTypeScriptTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePublishTypeScriptTest.groovy
@@ -90,12 +90,12 @@ class ConjurePublishTypeScriptTest extends ConfigurationCacheSpec {
                 ':api:compileConjureTypeScript',
                 ':api:installTypeScriptDependencies'
         )
-        directory('api/api-typescript/src/node_modules').exists()
+        directory('api/build/generated/sources/conjure-typescript/node_modules').exists()
     }
 
     def 'installTypeScriptDependencies is up-to-date when run for the second time'() {
         when:
-        !directory('api/api-typescript/src/node_modules').exists()
+        !directory('api/build/generated/sources/conjure-typescript/node_modules').exists()
         BuildResult first = runTasks('installTypeScriptDependencies')
 
         then:
@@ -103,7 +103,7 @@ class ConjurePublishTypeScriptTest extends ConfigurationCacheSpec {
                 ':api:compileConjureTypeScript',
                 ':api:installTypeScriptDependencies'
         )
-        directory('api/api-typescript/src/node_modules').exists()
+        directory('api/build/generated/sources/conjure-typescript/node_modules').exists()
 
         when:
         BuildResult second = runTasksWithConfigurationCache('-i', 'installTypeScriptDependencies')
@@ -152,8 +152,8 @@ class ConjurePublishTypeScriptTest extends ConfigurationCacheSpec {
         server.takeRequest(100, TimeUnit.MILLISECONDS).path == "/-/user/org.couchdb.user:user"
         server.takeRequest(100, TimeUnit.MILLISECONDS).path == "/conjure-client"
         server.takeRequest(100, TimeUnit.MILLISECONDS).path == "/typescript"
-        file('api/api-typescript/src/.npmrc').exists()
-        file('api/api-typescript/src/.npmrc').readLines()
+        file('api/build/generated/sources/conjure-typescript/.npmrc').exists()
+        file('api/build/generated/sources/conjure-typescript/.npmrc').readLines()
                 .containsAll('registry=http://localhost:8888/', '//localhost:8888/:_authToken=42')
         result.tasks(TaskOutcome.SUCCESS)*.path.contains(':api:generateNpmrc')
         !result.tasks(TaskOutcome.SKIPPED)*.path.contains(':api:generateNpmrc')
@@ -175,7 +175,7 @@ class ConjurePublishTypeScriptTest extends ConfigurationCacheSpec {
                 ':api:compileConjureTypeScript',
                 ':api:compileTypeScript'
         )
-        file('api/api-typescript/src/index.js').text.contains('export * from "./api";')
+        file('api/build/generated/sources/conjure-typescript/index.js').text.contains('export * from "./api";')
     }
 
     def 'compileTypeScript is up-to-date when run for the second time'() {
@@ -219,8 +219,8 @@ class ConjurePublishTypeScriptTest extends ConfigurationCacheSpec {
         BuildResult result = runTasks('publish')
 
         then:
-        file('api/api-typescript/src/.npmrc').text.contains('registry=http://localhost:8888/')
-        file('api/api-typescript/src/.npmrc').text.contains('//localhost:8888/:_authToken=atoken')
+        file('api/build/generated/sources/conjure-typescript/.npmrc').text.contains('registry=http://localhost:8888/')
+        file('api/build/generated/sources/conjure-typescript/.npmrc').text.contains('//localhost:8888/:_authToken=atoken')
         result.tasks(TaskOutcome.SUCCESS)*.path.containsAll(
                 ':api:generateNpmrc',
                 ':api:compileTypeScript',
@@ -260,8 +260,8 @@ class ConjurePublishTypeScriptTest extends ConfigurationCacheSpec {
         BuildResult result = runTasks('publish')
 
         then:
-        file('api/api-typescript/src/.npmrc').text.contains('registry=http://localhost:8888/')
-        file('api/api-typescript/src/.npmrc').text.contains('//localhost:8888/:_authToken=registry-token')
+        file('api/build/generated/sources/conjure-typescript/.npmrc').text.contains('registry=http://localhost:8888/')
+        file('api/build/generated/sources/conjure-typescript/.npmrc').text.contains('//localhost:8888/:_authToken=registry-token')
         result.tasks(TaskOutcome.SUCCESS)*.path.containsAll(
                 ':api:generateNpmrc',
                 ':api:installTypeScriptDependencies',
@@ -305,8 +305,8 @@ class ConjurePublishTypeScriptTest extends ConfigurationCacheSpec {
         BuildResult result = runTasks('publish')
 
         then:
-        file('api/api-typescript/src/.npmrc').text.contains('@test:registry=http://localhost:8888/')
-        file('api/api-typescript/src/.npmrc').text.contains('//localhost:8888/:_authToken=atoken')
+        file('api/build/generated/sources/conjure-typescript/.npmrc').text.contains('@test:registry=http://localhost:8888/')
+        file('api/build/generated/sources/conjure-typescript/.npmrc').text.contains('//localhost:8888/:_authToken=atoken')
         result.tasks(TaskOutcome.SUCCESS)*.path.containsAll(
                 ':api:generateNpmrc',
                 ':api:compileTypeScript',

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePublishTypeScriptTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePublishTypeScriptTest.groovy
@@ -90,12 +90,12 @@ class ConjurePublishTypeScriptTest extends ConfigurationCacheSpec {
                 ':api:compileConjureTypeScript',
                 ':api:installTypeScriptDependencies'
         )
-        directory('api/build/generated/sources/conjure-typescript/node_modules').exists()
+        directory('api/api-typescript/build/generated/sources/conjure-typescript/node_modules').exists()
     }
 
     def 'installTypeScriptDependencies is up-to-date when run for the second time'() {
         when:
-        !directory('api/build/generated/sources/conjure-typescript/node_modules').exists()
+        !directory('api/api-typescript/build/generated/sources/conjure-typescript/node_modules').exists()
         BuildResult first = runTasks('installTypeScriptDependencies')
 
         then:
@@ -103,7 +103,7 @@ class ConjurePublishTypeScriptTest extends ConfigurationCacheSpec {
                 ':api:compileConjureTypeScript',
                 ':api:installTypeScriptDependencies'
         )
-        directory('api/build/generated/sources/conjure-typescript/node_modules').exists()
+        directory('api/api-typescript/build/generated/sources/conjure-typescript/node_modules').exists()
 
         when:
         BuildResult second = runTasksWithConfigurationCache('-i', 'installTypeScriptDependencies')
@@ -152,8 +152,8 @@ class ConjurePublishTypeScriptTest extends ConfigurationCacheSpec {
         server.takeRequest(100, TimeUnit.MILLISECONDS).path == "/-/user/org.couchdb.user:user"
         server.takeRequest(100, TimeUnit.MILLISECONDS).path == "/conjure-client"
         server.takeRequest(100, TimeUnit.MILLISECONDS).path == "/typescript"
-        file('api/build/generated/sources/conjure-typescript/.npmrc').exists()
-        file('api/build/generated/sources/conjure-typescript/.npmrc').readLines()
+        file('api/api-typescript/build/generated/sources/conjure-typescript/.npmrc').exists()
+        file('api/api-typescript/build/generated/sources/conjure-typescript/.npmrc').readLines()
                 .containsAll('registry=http://localhost:8888/', '//localhost:8888/:_authToken=42')
         result.tasks(TaskOutcome.SUCCESS)*.path.contains(':api:generateNpmrc')
         !result.tasks(TaskOutcome.SKIPPED)*.path.contains(':api:generateNpmrc')
@@ -175,7 +175,7 @@ class ConjurePublishTypeScriptTest extends ConfigurationCacheSpec {
                 ':api:compileConjureTypeScript',
                 ':api:compileTypeScript'
         )
-        file('api/build/generated/sources/conjure-typescript/index.js').text.contains('export * from "./api";')
+        file('api/api-typescript/build/generated/sources/conjure-typescript/index.js').text.contains('export * from "./api";')
     }
 
     def 'compileTypeScript is up-to-date when run for the second time'() {
@@ -219,8 +219,8 @@ class ConjurePublishTypeScriptTest extends ConfigurationCacheSpec {
         BuildResult result = runTasks('publish')
 
         then:
-        file('api/build/generated/sources/conjure-typescript/.npmrc').text.contains('registry=http://localhost:8888/')
-        file('api/build/generated/sources/conjure-typescript/.npmrc').text.contains('//localhost:8888/:_authToken=atoken')
+        file('api/api-typescript/build/generated/sources/conjure-typescript/.npmrc').text.contains('registry=http://localhost:8888/')
+        file('api/api-typescript/build/generated/sources/conjure-typescript/.npmrc').text.contains('//localhost:8888/:_authToken=atoken')
         result.tasks(TaskOutcome.SUCCESS)*.path.containsAll(
                 ':api:generateNpmrc',
                 ':api:compileTypeScript',
@@ -260,8 +260,8 @@ class ConjurePublishTypeScriptTest extends ConfigurationCacheSpec {
         BuildResult result = runTasks('publish')
 
         then:
-        file('api/build/generated/sources/conjure-typescript/.npmrc').text.contains('registry=http://localhost:8888/')
-        file('api/build/generated/sources/conjure-typescript/.npmrc').text.contains('//localhost:8888/:_authToken=registry-token')
+        file('api/api-typescript/build/generated/sources/conjure-typescript/.npmrc').text.contains('registry=http://localhost:8888/')
+        file('api/api-typescript/build/generated/sources/conjure-typescript/.npmrc').text.contains('//localhost:8888/:_authToken=registry-token')
         result.tasks(TaskOutcome.SUCCESS)*.path.containsAll(
                 ':api:generateNpmrc',
                 ':api:installTypeScriptDependencies',
@@ -305,8 +305,8 @@ class ConjurePublishTypeScriptTest extends ConfigurationCacheSpec {
         BuildResult result = runTasks('publish')
 
         then:
-        file('api/build/generated/sources/conjure-typescript/.npmrc').text.contains('@test:registry=http://localhost:8888/')
-        file('api/build/generated/sources/conjure-typescript/.npmrc').text.contains('//localhost:8888/:_authToken=atoken')
+        file('api/api-typescript/build/generated/sources/conjure-typescript/.npmrc').text.contains('@test:registry=http://localhost:8888/')
+        file('api/api-typescript/build/generated/sources/conjure-typescript/.npmrc').text.contains('//localhost:8888/:_authToken=atoken')
         result.tasks(TaskOutcome.SUCCESS)*.path.containsAll(
                 ':api:generateNpmrc',
                 ':api:compileTypeScript',

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
@@ -161,7 +161,7 @@ class ConjureServiceDependencyTest extends ConfigurationCacheSpec implements Fil
 
         then:
         result.tasks(TaskOutcome.SUCCESS)*.path.contains(':api:generateConjureServiceDependencies')
-        file('api/api-typescript/src/package.json').text.contains('sls')
+        file('api/build/generated/sources/conjure-typescript/package.json').text.contains('sls')
     }
 
     def "does not pass product dependencies to java objects or undertow"() {

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureServiceDependencyTest.groovy
@@ -161,7 +161,7 @@ class ConjureServiceDependencyTest extends ConfigurationCacheSpec implements Fil
 
         then:
         result.tasks(TaskOutcome.SUCCESS)*.path.contains(':api:generateConjureServiceDependencies')
-        file('api/build/generated/sources/conjure-typescript/package.json').text.contains('sls')
+        file('api/api-typescript/build/generated/sources/conjure-typescript/package.json').text.contains('sls')
     }
 
     def "does not pass product dependencies to java objects or undertow"() {


### PR DESCRIPTION
## Before this PR

The conjure TypeScript generator outputs to the typescript subproject's `src/` directory ([originally introduced](https://github.com/palantir/gradle-conjure/pull/792)). When consumer repos broadly apply `java-library` to all subprojects, the typescript subproject inherits Java tasks whose input/output directories overlap with conjure's `src/` output. On Gradle 9, this causes implicit dependency validation errors for `processResources`, `compileJava`, etc.

#1949 partially addressed this by disabling `JavaCompile` tasks, but other task types like `processResources` still trigger the same error — disabling them one-by-one is whack-a-mole.

## After this PR

==CHANGELOG_MSG==
The conjure TypeScript generator now outputs to `build/generated/sources/conjure-typescript/` instead of `src/`.
==CHANGELOG_MSG==

Moves the output to `build/generated/sources/conjure-typescript/`, matching the Java generators' convention. No directory overlap with Java source sets means no implicit dependency errors, regardless of what plugins are applied. 

Also removes the `JavaCompile` disable workaround from #1949 and the `.gitignore` generation (unnecessary since `build/` is already gitignored).

## Possible downsides?

Breaking change for repos assume the location of the typescript output - although I think this was always meant as more of an implementation detail than a location for users to interact with

## Testing

All tests passing, fixes Gradle 9 issues