### PR TITLE
Make custom generator resolution Gradle 9 compatible

### DIFF
--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjureLocalPlugin.java
@@ -166,9 +166,8 @@ public final class ConjureLocalPlugin implements Plugin<Project> {
 
         genericSubProjects.forEach((subprojectName, subproject) -> {
             // We create a lazy filtered FileCollection to avoid using afterEvaluate.
-            @SuppressWarnings("for-rollout:deprecation")
-            FileCollection matchingGeneratorDeps = conjureGeneratorsConfiguration.fileCollection(
-                    dep -> dep.getName().equals(ConjurePlugin.CONJURE_GENERATOR_DEP_PREFIX + subprojectName));
+            FileCollection matchingGeneratorDeps =
+                    ConjurePlugin.generatorArtifacts(conjureGeneratorsConfiguration, subprojectName);
 
             @SuppressWarnings("for-rollout:deprecation")
             TaskProvider<ExtractExecutableTask> extractConjureGeneratorTask = ExtractExecutableTask.createExtractTask(

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -593,7 +593,10 @@ public final class ConjurePlugin implements Plugin<Project> {
         });
     }
 
-    // Replaces Configuration#fileCollection(Spec), removed in Gradle 9.
+    /**
+     * Lazily resolves the single generator distribution for {@code generatorName} out of the (potentially
+     * multi-generator) {@code conjureGenerators} configuration.
+     */
     static FileCollection generatorArtifacts(Configuration conjureGeneratorsConfiguration, String generatorName) {
         String generatorModuleName = CONJURE_GENERATOR_DEP_PREFIX + generatorName;
         return conjureGeneratorsConfiguration

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -593,16 +593,7 @@ public final class ConjurePlugin implements Plugin<Project> {
         });
     }
 
-    /**
-     * Lazily resolves the single generator distribution for {@code generatorName} out of the (potentially
-     * multi-generator) {@code conjureGenerators} configuration.
-     *
-     * <p>This replaces {@code Configuration#fileCollection(Spec)} (removed in Gradle 9) with an artifact view
-     * filtered to the {@code conjure-<generatorName>} module. The view is lazy and carries the configuration's
-     * task dependencies, so it remains configuration-cache friendly, and — because each generator is published
-     * as a single self-contained distribution under a distinct module — selecting by module name yields exactly
-     * the one artifact the extract task expects.
-     */
+    // Replaces Configuration#fileCollection(Spec), removed in Gradle 9.
     static FileCollection generatorArtifacts(Configuration conjureGeneratorsConfiguration, String generatorName) {
         String generatorModuleName = CONJURE_GENERATOR_DEP_PREFIX + generatorName;
         return conjureGeneratorsConfiguration

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -51,6 +51,7 @@ import org.gradle.api.Task;
 import org.gradle.api.UnknownTaskException;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.logging.Logger;
@@ -564,9 +565,8 @@ public final class ConjurePlugin implements Plugin<Project> {
             String conjureLanguage = extractSubprojectLanguage(project.getName(), subprojectName);
 
             // We create a lazy filtered FileCollection to avoid using afterEvaluate.
-            @SuppressWarnings("for-rollout:deprecation")
-            FileCollection matchingGeneratorDeps = conjureGeneratorsConfiguration.fileCollection(
-                    dep -> dep.getName().equals(CONJURE_GENERATOR_DEP_PREFIX + conjureLanguage));
+            FileCollection matchingGeneratorDeps =
+                    generatorArtifacts(conjureGeneratorsConfiguration, conjureLanguage);
 
             @SuppressWarnings("for-rollout:deprecation")
             TaskProvider<ExtractExecutableTask> extractConjureGeneratorTask = ExtractExecutableTask.createExtractTask(
@@ -592,6 +592,27 @@ public final class ConjurePlugin implements Plugin<Project> {
                     });
             compileConjure.configure(t -> t.dependsOn(conjureLocalGenerateTask));
         });
+    }
+
+    /**
+     * Lazily resolves the single generator distribution for {@code generatorName} out of the (potentially
+     * multi-generator) {@code conjureGenerators} configuration.
+     *
+     * <p>This replaces {@code Configuration#fileCollection(Spec)} (removed in Gradle 9) with an artifact view
+     * filtered to the {@code conjure-<generatorName>} module. The view is lazy and carries the configuration's
+     * task dependencies, so it remains configuration-cache friendly, and — because each generator is published
+     * as a single self-contained distribution under a distinct module — selecting by module name yields exactly
+     * the one artifact the extract task expects.
+     */
+    static FileCollection generatorArtifacts(Configuration conjureGeneratorsConfiguration, String generatorName) {
+        String generatorModuleName = CONJURE_GENERATOR_DEP_PREFIX + generatorName;
+        return conjureGeneratorsConfiguration
+                .getIncoming()
+                .artifactView(viewConfiguration -> viewConfiguration.componentFilter(
+                        componentIdentifier ->
+                                componentIdentifier instanceof ModuleComponentIdentifier moduleComponentIdentifier
+                                        && moduleComponentIdentifier.getModule().equals(generatorModuleName)))
+                .getFiles();
     }
 
     /**

--- a/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
+++ b/gradle-conjure/src/main/java/com/palantir/gradle/conjure/ConjurePlugin.java
@@ -565,8 +565,7 @@ public final class ConjurePlugin implements Plugin<Project> {
             String conjureLanguage = extractSubprojectLanguage(project.getName(), subprojectName);
 
             // We create a lazy filtered FileCollection to avoid using afterEvaluate.
-            FileCollection matchingGeneratorDeps =
-                    generatorArtifacts(conjureGeneratorsConfiguration, conjureLanguage);
+            FileCollection matchingGeneratorDeps = generatorArtifacts(conjureGeneratorsConfiguration, conjureLanguage);
 
             @SuppressWarnings("for-rollout:deprecation")
             TaskProvider<ExtractExecutableTask> extractConjureGeneratorTask = ExtractExecutableTask.createExtractTask(
@@ -608,10 +607,9 @@ public final class ConjurePlugin implements Plugin<Project> {
         String generatorModuleName = CONJURE_GENERATOR_DEP_PREFIX + generatorName;
         return conjureGeneratorsConfiguration
                 .getIncoming()
-                .artifactView(viewConfiguration -> viewConfiguration.componentFilter(
-                        componentIdentifier ->
-                                componentIdentifier instanceof ModuleComponentIdentifier moduleComponentIdentifier
-                                        && moduleComponentIdentifier.getModule().equals(generatorModuleName)))
+                .artifactView(viewConfiguration -> viewConfiguration.componentFilter(componentIdentifier ->
+                        componentIdentifier instanceof ModuleComponentIdentifier moduleComponentIdentifier
+                                && moduleComponentIdentifier.getModule().equals(generatorModuleName)))
                 .getFiles();
     }
 

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalPluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjureLocalPluginTest.groovy
@@ -108,15 +108,18 @@ class ConjureLocalPluginTest extends ConfigurationCacheSpec implements FileExist
         fileExists('python/python/conjure-api/conjure_spec/__init__.py')
     }
 
-    def "custom generator throws if generator missing"() {
+    def "custom generator throws if generator missing: #gradleVersion"() {
         addSubproject("postman")
 
         expect:
         def output = runTasksAndFailWithConfigurationCache("generateConjure").output
         output.contains("without corresponding generator dependency")
+
+        where:
+        gradleVersion << TestVersions.VERSIONS
     }
 
-    def 'supports custom postman generator'() {
+    def 'supports custom postman generator: #gradleVersion'() {
         addSubproject("postman")
 
         when:
@@ -132,5 +135,8 @@ class ConjureLocalPluginTest extends ConfigurationCacheSpec implements FileExist
         fileExists('postman/postman/conjure-api/conjure-api.postman_collection.json')
         file('postman/postman/conjure-api/conjure-api.postman_collection.json')
                 .text.contains(""""version" : "${TestVersions.CONJURE}\"""")
+
+        where:
+        gradleVersion << TestVersions.VERSIONS
     }
 }

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -134,6 +134,26 @@ class ConjurePluginTest extends ConfigurationCacheSpec implements FileExists {
         'peer'     | ''
     }
 
+    def 'resolves a custom (generic) generator distribution'() {
+        setup:
+        file('settings.gradle') << "include 'api:api-postman'\n"
+        file('api/build.gradle') << """
+        dependencies {
+            conjureGenerators 'com.palantir.conjure.postman:conjure-postman:${TestVersions.CONJURE_POSTMAN}'
+        }
+        """.stripIndent()
+
+        when:
+        // extractConjurePostman is wired off ConjurePlugin.generatorArtifacts: the artifact view must select
+        // exactly the single conjure-postman distribution out of the (multi-generator) conjureGenerators
+        // configuration, otherwise ExtractExecutableTask fails ("Expected exactly one dependency ...").
+        BuildResult result = runTasksWithConfigurationCache(':api:extractConjurePostman')
+
+        then:
+        result.task(':api:extractConjurePostman').outcome == TaskOutcome.SUCCESS
+        fileExists('api/api-postman/build/generator/bin/conjure-postman')
+    }
+
     def 'check code compiles: #location'() {
         setup:
         updateSettings(prefix)

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -673,7 +673,7 @@ class ConjurePluginTest extends ConfigurationCacheSpec implements FileExists {
         'peer'     | ''
     }
 
-    def 'supports generic generators: #location'() {
+    def 'supports generic generators: #location (gradle #gradleVersion)'() {
         setup:
         addSubproject('api:api-postman')
 
@@ -706,9 +706,9 @@ class ConjurePluginTest extends ConfigurationCacheSpec implements FileExists {
         file(prefixPath(prefix, 'api-postman/src/api.postman_collection.json')).text.contains('"version" : "1.0.0"')
 
         where:
-        location   | prefix
-        'sub'      | 'api'
-        'peer'     | ''
+        [gradleVersion, location, prefix] << [TestVersions.VERSIONS, [['sub', 'api'], ['peer', '']]]
+                .combinations()
+                .collect { [it[0]] + it[1] }
     }
 
     def 'generic setup is a no-op if there no generic subprojects: #location'() {

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -134,24 +134,6 @@ class ConjurePluginTest extends ConfigurationCacheSpec implements FileExists {
         'peer'     | ''
     }
 
-    def 'resolves a custom (generic) generator distribution'() {
-        setup:
-        file('settings.gradle') << "include 'api:api-postman'\n"
-        file('api/build.gradle') << """
-        dependencies {
-            conjureGenerators 'com.palantir.conjure.postman:conjure-postman:${TestVersions.CONJURE_POSTMAN}'
-        }
-        """.stripIndent()
-
-        when:
-        // The artifact view must select exactly the conjure-postman distribution out of conjureGenerators.
-        BuildResult result = runTasksWithConfigurationCache(':api:extractConjurePostman')
-
-        then:
-        result.task(':api:extractConjurePostman').outcome == TaskOutcome.SUCCESS
-        fileExists('api/api-postman/build/generator/bin/conjure-postman')
-    }
-
     def 'check code compiles: #location'() {
         setup:
         updateSettings(prefix)

--- a/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
+++ b/gradle-conjure/src/test/groovy/com/palantir/gradle/conjure/ConjurePluginTest.groovy
@@ -144,9 +144,7 @@ class ConjurePluginTest extends ConfigurationCacheSpec implements FileExists {
         """.stripIndent()
 
         when:
-        // extractConjurePostman is wired off ConjurePlugin.generatorArtifacts: the artifact view must select
-        // exactly the single conjure-postman distribution out of the (multi-generator) conjureGenerators
-        // configuration, otherwise ExtractExecutableTask fails ("Expected exactly one dependency ...").
+        // The artifact view must select exactly the conjure-postman distribution out of conjureGenerators.
         BuildResult result = runTasksWithConfigurationCache(':api:extractConjurePostman')
 
         then:

--- a/gradle-conjure/src/test/java/com/palantir/gradle/conjure/TestVersions.java
+++ b/gradle-conjure/src/test/java/com/palantir/gradle/conjure/TestVersions.java
@@ -21,7 +21,7 @@ import com.google.common.collect.ImmutableList;
 public final class TestVersions {
     private TestVersions() {}
 
-    public static final ImmutableList<String> VERSIONS = ImmutableList.of("7.6.4", "8.8");
+    public static final ImmutableList<String> VERSIONS = ImmutableList.of("7.6.4", "8.8", "9.3.1");
 
     public static final String CONJURE = "4.48.0";
     public static final String CONJURE_JAVA = "8.22.0";


### PR DESCRIPTION
<!-- g9-fixbot -->
## Before this PR

The generic (custom) generator wiring resolved a single generator distribution out of the multi-generator `conjureGenerators` configuration using `Configuration#fileCollection(Spec)`:

```java
conjureGeneratorsConfiguration.fileCollection(dep -> dep.getName().equals("conjure-" + name));
```

That `fileCollection(Spec)` overload was removed in Gradle 9, so applying the `conjure` / `conjure-local` plugins to a project that declares a custom generator (e.g. `conjureGenerators '...:conjure-postman'`) fails on Gradle 9.

## After this PR

Both call sites resolve the generator distribution through an artifact view filtered to the `conjure-<name>` module, sharing a single `ConjurePlugin.generatorArtifacts(...)` helper:

```java
conjureGeneratorsConfiguration.getIncoming()
        .artifactView(view -> view.componentFilter(id ->
                id instanceof ModuleComponentIdentifier module
                        && module.getModule().equals("conjure-" + name)))
        .getFiles();
```

Why this is the correct replacement:
- `incoming.artifactView { componentFilter { ... } }` has existed since Gradle 5, so it does not raise the plugin's minimum Gradle version.
- The view is lazy and carries the configuration's task dependencies, so it stays configuration-cache compatible (verified under `--configuration-cache`).
- Each generator is published as a single self-contained distribution under a distinct module, so filtering by module name yields exactly the one artifact `ExtractExecutableTask` expects (it asserts a single file) — behaviour is unchanged.

## Testing

`9.3.1` was added to `TestVersions.VERSIONS`, and **every test that exercises the migrated `generatorArtifacts` resolution now runs across the matrix (incl. Gradle 9.3.1)** — covering both call sites of the shared helper:

- `ConjurePluginTest` → `supports generic generators` (`sub` + `peer`)
- `ConjureLocalPluginTest` → `supports custom postman generator`, `custom generator throws if generator missing`

All iterations pass on 7.6.4 / 8.8 / 9.3.1, so the artifact-view resolution is proven on Gradle 9 from both the `conjure` and `conjure-local` plugins — not just 7.x/8.x.

## Possible downsides?

None expected. The artifact view selects the same single generator distribution the previous `fileCollection(Spec)` call did; the change is behaviour-preserving and keeps the existing Gradle compatibility floor.


